### PR TITLE
Fix response body dump for 2.x.x version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Please follow [the Keep a Changelog standard](https://keepachangelog.com/en/1.0.
 
 ### Fixed
 
-* do not json.dumps the body while converting endpoint response to version if body is empty
+* If a user returned a FastAPI/Starlette Response with an empty body, we still tried to serialize it which caused an invalid response body
 
 ## [2.3.4]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@
 All notable changes to this project will be documented in this file.
 Please follow [the Keep a Changelog standard](https://keepachangelog.com/en/1.0.0/).
 
-## [Unreleased]
+## [2.3.5]
+
+### Fixed
+
+* do not json.dumps the body while converting endpoint response to version if body is empty
 
 ## [2.3.4]
 

--- a/cadwyn/structure/versions.py
+++ b/cadwyn/structure/versions.py
@@ -446,7 +446,10 @@ class VersionBundle:
             path,
             method,
         )
-        if isinstance(response_or_response_body, FastapiResponse):
+        if isinstance(response_or_response_body, FastapiResponse) and response_info.body:
+            # None is a valid response body, when a user returns just a status code
+            # dumping it will result in a 'null' string, which doesnt correlate with the content-length
+
             # TODO: Give user the ability to specify their own renderer
             # TODO: Only do this if there are migrations
             response_info._response.body = json.dumps(response_info.body).encode()

--- a/cadwyn/structure/versions.py
+++ b/cadwyn/structure/versions.py
@@ -446,13 +446,17 @@ class VersionBundle:
             path,
             method,
         )
-        if isinstance(response_or_response_body, FastapiResponse) and response_info.body:
-            # None is a valid response body, when a user returns just a status code
-            # dumping it will result in a 'null' string, which doesnt correlate with the content-length
-
-            # TODO: Give user the ability to specify their own renderer
-            # TODO: Only do this if there are migrations
-            response_info._response.body = json.dumps(response_info.body).encode()
+        if isinstance(response_or_response_body, FastapiResponse):
+            # a webserver (uvicorn for instance) calculates the body at the endpoint level.
+            # if an endpoint returns no "body", its content-length will be set to 0
+            # json.dums(None) results into "null", and content-length should be 4,
+            # but it was already calculated to 0 which causes
+            # `RuntimeError: Response content longer than Content-Length` or
+            # `Too much data for declared Content-Length`, based on the protocol
+            if response_info.body is not None:
+                # TODO: Give user the ability to specify their own renderer
+                # TODO: Only do this if there are migrations
+                response_info._response.body = json.dumps(response_info.body).encode()
             return response_info._response
         return response_info.body
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cadwyn"
-version = "2.3.4"
+version = "2.3.5"
 description = "Modern Stripe-like API versioning in FastAPI"
 authors = ["Stanislav Zmiev <zmievsa@gmail.com>"]
 license = "MIT"

--- a/tests/test_data_migrations.py
+++ b/tests/test_data_migrations.py
@@ -498,6 +498,76 @@ class TestResponseMigrations:
         )
         assert resp.status_code == 301
 
+    def test__fastapi_response_migration__response_only_has_status_code_and_there_is_a_migration(
+        self,
+        create_versioned_clients: CreateVersionedClients,
+        test_path: Literal["/test"],
+        latest_module: ModuleType,
+        router: VersionedAPIRouter,
+    ):
+        @router.post(test_path, response_model=latest_module.AnyResponseSchema)
+        async def post_endpoint(request: Request):
+            return Response(status_code=200)
+
+        @convert_response_to_previous_version_for(latest_module.AnyResponseSchema)
+        def migrator(response: ResponseInfo):
+            response.status_code = 201
+
+        clients = create_versioned_clients(version_change(migrator=migrator))
+        resp = clients[date(2000, 1, 1)].post(test_path, json={})
+        assert resp.content == b""
+        assert dict(resp.headers) == (
+            {
+                "content-length": "0",
+                "x-api-version": "2000-01-01",
+            }
+        )
+        assert resp.status_code == 201
+        assert dict(resp.cookies) == {}
+
+        resp = clients[date(2001, 1, 1)].post(test_path, json={})
+        assert resp.content == b""
+        assert dict(resp.headers) == (
+            {
+                "content-length": "0",
+                "x-api-version": "2001-01-01",
+            }
+        )
+        assert resp.status_code == 200
+
+    def test__fastapi_response_migration__response_only_has_status_code_and_there_is_no_migration(
+        self,
+        create_versioned_clients: CreateVersionedClients,
+        test_path: Literal["/test"],
+        latest_module: ModuleType,
+        router: VersionedAPIRouter,
+    ):
+        @router.post(test_path, response_model=latest_module.AnyResponseSchema)
+        async def post_endpoint(request: Request):
+            return Response(status_code=200)
+
+        clients = create_versioned_clients(version_change())
+        resp = clients[date(2000, 1, 1)].post(test_path, json={})
+        assert resp.content == b""
+        assert dict(resp.headers) == (
+            {
+                "content-length": "0",
+                "x-api-version": "2000-01-01",
+            }
+        )
+        assert resp.status_code == 200
+        assert dict(resp.cookies) == {}
+
+        resp = clients[date(2001, 1, 1)].post(test_path, json={})
+        assert resp.content == b""
+        assert dict(resp.headers) == (
+            {
+                "content-length": "0",
+                "x-api-version": "2001-01-01",
+            }
+        )
+        assert resp.status_code == 200
+
 
 class TestHowAndWhenMigrationsApply:
     def test__migrate__with_no_migrations__should_not_raise_error(


### PR DESCRIPTION
fixed uvicorn `Response content longer than Content-Length` error, when an endpoint returns just a status code

```
@router.delete("/")
async def delete():
    return Response(status_code=status.HTTP_204_NO_CONTENT)
```

please note, this is a branch from fae0295 to hotfix 2.x.x version, so I need a separate branch for that. Could you create it? Otherwise there are conflicts

[Here](https://github.com/zmievsa/cadwyn/pull/106) is an MR for the main