### PR TITLE
Fix response body dump main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Please follow [the Keep a Changelog standard](https://keepachangelog.com/en/1.0.
 
 ## [Unreleased]
 
+## [3.0.2]
+
+### Fixed
+
+* do not json.dumps the body while converting endpoint response to version if body is empty
+
+## [Unreleased]
+
 ## [3.0.0]
 
 ### Added

--- a/cadwyn/structure/versions.py
+++ b/cadwyn/structure/versions.py
@@ -448,7 +448,10 @@ class VersionBundle:
             path,
             method,
         )
-        if isinstance(response_or_response_body, FastapiResponse):
+        if isinstance(response_or_response_body, FastapiResponse) and response_info.body:
+            # None is a valid response body, when a user returns just a status code
+            # dumping it will result in a 'null' string, which doesnt correlate with the content-length
+
             # TODO: Give user the ability to specify their own renderer
             # TODO: Only do this if there are migrations
             response_info._response.body = json.dumps(response_info.body).encode()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cadwyn"
-version = "3.0.1"
+version = "3.0.2"
 description = "Production-ready community-driven modern Stripe-like API versioning in FastAPI"
 authors = ["Stanislav Zmiev <zmievsa@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
fixed uvicorn Response content longer than Content-Length error, when an endpoint returns just a status code

@router.delete("/")
async def delete():
    return Response(status_code=status.HTTP_204_NO_CONTENT)
