### PR TITLE
Fix response.body property access for StreamingResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Please follow [the Keep a Changelog standard](https://keepachangelog.com/en/1.0.
 
 ### Fixed
 
-* If a user uses a FastAPI/Starlette `StreamingResponse`, we still tried to access body param which caused an `AttributeError`
+* If a user used a FastAPI/Starlette `StreamingResponse`, we still tried to access its `body` attribute which caused an `AttributeError`
 
 ## [3.2.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Please follow [the Keep a Changelog standard](https://keepachangelog.com/en/1.0.
 
 ## [Unreleased]
 
+## [3.2.1]
+
+### Fixed
+
+* If a user uses a FastAPI/Starlette `StreamingResponse`, we still tried to access body param which caused an `AttributeError`
+
+## [Unreleased]
+
 ## [3.2.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@ Please follow [the Keep a Changelog standard](https://keepachangelog.com/en/1.0.
 
 * If a user uses a FastAPI/Starlette `StreamingResponse`, we still tried to access body param which caused an `AttributeError`
 
-## [Unreleased]
-
 ## [3.2.0]
 
 ### Added

--- a/cadwyn/structure/versions.py
+++ b/cadwyn/structure/versions.py
@@ -445,7 +445,9 @@ class VersionBundle:
         api_version = self.api_version_var.get()
         if api_version is None:
             return response_or_response_body
-        if hasattr(response_or_response_body, "body"):
+        # You might expect the first check to be enough but it's not: starlette actively breaks
+        # Liskov Substitution principle and doesn't define `body` for `StreamingResponse`
+        if isinstance(response_or_response_body, FastapiResponse) and hasattr(response_or_response_body, "body"):
             response_info = ResponseInfo(
                 response_or_response_body,
                 # TODO (https://github.com/zmievsa/cadwyn/issues/51): Only do this if there are migrations

--- a/cadwyn/structure/versions.py
+++ b/cadwyn/structure/versions.py
@@ -471,7 +471,7 @@ class VersionBundle:
             path,
             method,
         )
-        if hasattr(response_or_response_body, "body"):
+        if isinstance(response_or_response_body, FastapiResponse) and hasattr(response_or_response_body, "body"):
             # a webserver (uvicorn for instance) calculates the body at the endpoint level.
             # if an endpoint returns no "body", its content-length will be set to 0
             # json.dumps(None) results into "null", and content-length should be 4,

--- a/cadwyn/structure/versions.py
+++ b/cadwyn/structure/versions.py
@@ -445,7 +445,7 @@ class VersionBundle:
         api_version = self.api_version_var.get()
         if api_version is None:
             return response_or_response_body
-        if isinstance(response_or_response_body, FastapiResponse):
+        if hasattr(response_or_response_body, "body"):
             response_info = ResponseInfo(
                 response_or_response_body,
                 # TODO (https://github.com/zmievsa/cadwyn/issues/51): Only do this if there are migrations
@@ -469,10 +469,10 @@ class VersionBundle:
             path,
             method,
         )
-        if isinstance(response_or_response_body, FastapiResponse):
+        if hasattr(response_or_response_body, "body"):
             # a webserver (uvicorn for instance) calculates the body at the endpoint level.
             # if an endpoint returns no "body", its content-length will be set to 0
-            # json.dums(None) results into "null", and content-length should be 4,
+            # json.dumps(None) results into "null", and content-length should be 4,
             # but it was already calculated to 0 which causes
             # `RuntimeError: Response content longer than Content-Length` or
             # `Too much data for declared Content-Length`, based on the protocol

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cadwyn"
-version = "3.2.0"
+version = "3.2.1"
 description = "Production-ready community-driven modern Stripe-like API versioning in FastAPI"
 authors = ["Stanislav Zmiev <zmievsa@gmail.com>"]
 license = "MIT"

--- a/tests/test_data_migrations.py
+++ b/tests/test_data_migrations.py
@@ -3,6 +3,7 @@ import re
 from collections.abc import Callable, Coroutine
 from contextvars import ContextVar
 from datetime import date
+from io import StringIO
 from types import ModuleType
 from typing import Annotated, Any, Literal, get_args
 
@@ -11,6 +12,7 @@ from dirty_equals import IsPartialDict, IsStr
 from fastapi import APIRouter, Body, Cookie, File, Header, Query, Request, Response, UploadFile
 from fastapi.responses import JSONResponse
 from fastapi.routing import APIRoute
+from starlette.responses import StreamingResponse
 
 from cadwyn import VersionedAPIRouter
 from cadwyn._compat import PYDANTIC_V2, model_dump
@@ -640,6 +642,33 @@ class TestResponseMigrations:
                 "x-api-version": "2001-01-01",
             }
         )
+        assert resp.status_code == 200
+
+    def test__fastapi_response_migration__response_is_streaming_response_and_there_is_a_migration(
+        self,
+        create_versioned_clients: CreateVersionedClients,
+        test_path: Literal["/test"],
+        latest_module: ModuleType,
+        router: VersionedAPIRouter,
+    ):
+        @router.post(test_path, response_model=latest_module.AnyResponseSchema)
+        async def post_endpoint(request: Request):
+            return StreamingResponse(StringIO(), status_code=200)
+
+        @convert_response_to_previous_version_for(latest_module.AnyResponseSchema)
+        def migrator(response: ResponseInfo):
+            response.body.status_code = 201
+
+        clients = create_versioned_clients(version_change(migrator=migrator))
+        resp = clients[date(2000, 1, 1)].post(test_path, json={})
+        assert resp.content == b""
+        assert dict(resp.headers) == {"x-api-version": "2000-01-01"}
+        assert resp.status_code == 201
+        assert dict(resp.cookies) == {}
+
+        resp = clients[date(2001, 1, 1)].post(test_path, json={})
+        assert resp.content == b""
+        assert dict(resp.headers) == {"x-api-version": "2001-01-01"}
         assert resp.status_code == 200
 
     def test__fastapi_response_migration__response_only_has_status_code_and_there_is_no_migration(

--- a/tests/test_data_migrations.py
+++ b/tests/test_data_migrations.py
@@ -653,7 +653,7 @@ class TestResponseMigrations:
     ):
         @router.post(test_path, response_model=latest_module.AnyResponseSchema)
         async def post_endpoint(request: Request):
-            return StreamingResponse(StringIO(), status_code=200)
+            return StreamingResponse(StringIO("streaming response"), status_code=200)
 
         @convert_response_to_previous_version_for(latest_module.AnyResponseSchema)
         def migrator(response: ResponseInfo):
@@ -661,13 +661,13 @@ class TestResponseMigrations:
 
         clients = create_versioned_clients(version_change(migrator=migrator))
         resp = clients[date(2000, 1, 1)].post(test_path, json={})
-        assert resp.content == b""
+        assert resp.content == b"streaming response"
         assert dict(resp.headers) == {"x-api-version": "2000-01-01"}
         assert resp.status_code == 201
         assert dict(resp.cookies) == {}
 
         resp = clients[date(2001, 1, 1)].post(test_path, json={})
-        assert resp.content == b""
+        assert resp.content == b"streaming response"
         assert dict(resp.headers) == {"x-api-version": "2001-01-01"}
         assert resp.status_code == 200
 


### PR DESCRIPTION
In my versioned API route, the response class is a `StreamingResponse`. 
When forming the `ResponseInfo`, I got an `AttributeError`. 

I found that there was an assumption that all Starlette Responses have a `.body` attribute, but `StreamingResponse` doesn't(`body_iterator` instead). Therefore, I suggest this change to check if the response object has a body attribute instead of using `isinstance()`.

P.S.
Overall, I started using this library and liked its concept of migrations, because full code copying was a nightmare without any light at the end of the tunnel. 

Looking forward to your response and comments!