### PR TITLE
Fix error text in signature validation of migration transformer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Please follow [the Keep a Changelog standard](https://keepachangelog.com/en/1.0.
 
 ### Fixed
 
-* If user made a wrong signature in the transformer of migration, text of an error suggested a wrong solution
+* If the user wrote a wrong signature in a transformer decorated by `convert_request_to_next_version_for` or `convert_response_to_previous_version_for`, the text of the error suggested the wrong argument count and names
 
 
 ## [3.3.4]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Please follow [the Keep a Changelog standard](https://keepachangelog.com/en/1.0.
 
 ## [Unreleased]
 
+## [3.3.5]
+
+### Fixed
+
+* If user made a wrong signature in the transformer of migration, text of an error suggested a wrong solution
+
+
 ## [3.3.4]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ Please follow [the Keep a Changelog standard](https://keepachangelog.com/en/1.0.
 
 ## [Unreleased]
 
-## [3.3.5]
 
 ### Fixed
 

--- a/cadwyn/structure/data.py
+++ b/cadwyn/structure/data.py
@@ -73,7 +73,7 @@ class _AlterDataInstruction:
         signature = inspect.signature(self.transformer)
         if list(signature.parameters) != [self._payload_arg_name]:
             raise ValueError(
-                f"Method '{self.transformer.__name__}' must have 2 parameters: cls and {self._payload_arg_name}",
+                f"Method '{self.transformer.__name__}' must have only 1 parameter: {self._payload_arg_name}",
             )
 
         functools.update_wrapper(self, self.transformer)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cadwyn"
-version = "3.3.5"
+version = "3.3.4"
 description = "Production-ready community-driven modern Stripe-like API versioning in FastAPI"
 authors = ["Stanislav Zmiev <zmievsa@gmail.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cadwyn"
-version = "3.3.4"
+version = "3.3.5"
 description = "Production-ready community-driven modern Stripe-like API versioning in FastAPI"
 authors = ["Stanislav Zmiev <zmievsa@gmail.com>"]
 license = "MIT"

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -338,7 +338,7 @@ def test__convert_response_to_previous_version_for__with_incorrect_args__should_
     with pytest.raises(
         ValueError,
         match=re.escape(
-            "Method 'my_conversion_method' must have 2 parameters: cls and response",
+            "Method 'my_conversion_method' must have only 1 parameter: response",
         ),
     ):
 
@@ -351,7 +351,7 @@ def test__convert_response_to_previous_version_for__with_no_args__should_raise_e
     with pytest.raises(
         ValueError,
         match=re.escape(
-            "Method 'my_conversion_method2' must have 2 parameters: cls and response",
+            "Method 'my_conversion_method2' must have only 1 parameter: response",
         ),
     ):
 
@@ -364,7 +364,7 @@ def test__convert_request_to_next_version_for__with_incorrect_args__should_raise
     with pytest.raises(
         ValueError,
         match=re.escape(
-            "Method 'my_conversion_method' must have 2 parameters: cls and request",
+            "Method 'my_conversion_method' must have only 1 parameter: request",
         ),
     ):
 
@@ -377,7 +377,7 @@ def test__convert_request_to_next_version_for__with_no_args__should_raise_error(
     with pytest.raises(
         ValueError,
         match=re.escape(
-            "Method 'my_conversion_method2' must have 2 parameters: cls and request",
+            "Method 'my_conversion_method2' must have only 1 parameter: request",
         ),
     ):
 


### PR DESCRIPTION
Right now, if I made a wrong signature in the transformer of migration, text of an error suggesting me a wrong solution.
```
Method 'my_conversion_method' must have 2 parameters: cls and response
```

But in reality - the correct signature is only 1 param: `response`

This PR fixing this misunderstanding