### PR TITLE
fix: CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,7 +122,7 @@ Please follow [the Keep a Changelog standard](https://keepachangelog.com/en/1.0.
 
 ### Removed
 
-* `cadwyn.internal_representation_of` because it is now done using [an annotation](https://docs.cadwyn.dev/reference#internal-request-body-representations)
+* `cadwyn.internal_body_representation_of` because it is now done using [an annotation](https://docs.cadwyn.dev/reference#internal-request-body-representations)
 
 ## [2.3.4]
 


### PR DESCRIPTION
There was no `cadwyn.internal_representation_of`; instead, there was `cadwyn.internal_body_representation_of`.

By the way, I'm not sure if the version should be bumped here or not. Please let me know if it should be, and I will update it.