### PR TITLE
Optimize the calls to enrich_swagger (#164)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Please follow [the Keep a Changelog standard](https://keepachangelog.com/en/1.0.
 
 ## [Unreleased]
 
+## [3.15.0]
+
+### Changed
+
+* Optimized the call to enrich_swagger, now happens on the startup event, once for the whole application.
+
 ## [3.14.0]
 
 ### Added

--- a/cadwyn/applications.py
+++ b/cadwyn/applications.py
@@ -19,7 +19,6 @@ from starlette.routing import BaseRoute, Route
 from starlette.types import Lifespan
 from typing_extensions import Self, deprecated
 
-from cadwyn._utils import same_definition_as_in
 from cadwyn.middleware import HeaderVersioningMiddleware, _get_api_version_dependency
 from cadwyn.route_generation import generate_versioned_routers
 from cadwyn.routing import _RootHeaderAPIRouter
@@ -138,6 +137,8 @@ class Cadwyn(FastAPI):
             api_version_header_name=api_version_header_name,
             api_version_var=self.versions.api_version_var,
         )
+
+        self.add_event_handler("startup", self.enrich_swagger)
 
         self.docs_url = docs_url
         self.redoc_url = redoc_url
@@ -297,91 +298,11 @@ class Cadwyn(FastAPI):
                 dependencies=[Depends(_get_api_version_dependency(self.router.api_version_header_name, header_value))],
             )
 
-        self.enrich_swagger()
         return added_routes
-
-    @same_definition_as_in(FastAPI.include_router)
-    def include_router(self, *args: Any, **kwargs: Any):
-        route = super().include_router(*args, **kwargs)
-        self.enrich_swagger()
-        return route
-
-    @same_definition_as_in(FastAPI.post)
-    def post(self, *args: Any, **kwargs: Any):
-        route = super().post(*args, **kwargs)
-        self.enrich_swagger()
-        return route
-
-    @same_definition_as_in(FastAPI.get)
-    def get(self, *args: Any, **kwargs: Any):
-        route = super().get(*args, **kwargs)
-        self.enrich_swagger()
-        return route
-
-    @same_definition_as_in(FastAPI.patch)
-    def patch(self, *args: Any, **kwargs: Any):
-        route = super().patch(*args, **kwargs)
-        self.enrich_swagger()
-        return route
-
-    @same_definition_as_in(FastAPI.delete)
-    def delete(self, *args: Any, **kwargs: Any):
-        route = super().delete(*args, **kwargs)
-        self.enrich_swagger()
-        return route
-
-    @same_definition_as_in(FastAPI.put)
-    def put(self, *args: Any, **kwargs: Any):
-        route = super().put(*args, **kwargs)
-        self.enrich_swagger()
-        return route
-
-    @same_definition_as_in(FastAPI.trace)
-    def trace(self, *args: Any, **kwargs: Any):  # pragma: no cover
-        route = super().trace(*args, **kwargs)
-        self.enrich_swagger()
-        return route
-
-    @same_definition_as_in(FastAPI.options)
-    def options(self, *args: Any, **kwargs: Any):
-        route = super().options(*args, **kwargs)
-        self.enrich_swagger()
-        return route
-
-    @same_definition_as_in(FastAPI.head)
-    def head(self, *args: Any, **kwargs: Any):
-        route = super().head(*args, **kwargs)
-        self.enrich_swagger()
-        return route
-
-    @same_definition_as_in(FastAPI.add_api_route)
-    def add_api_route(self, *args: Any, **kwargs: Any):
-        route = super().add_api_route(*args, **kwargs)
-        self.enrich_swagger()
-        return route
-
-    @same_definition_as_in(FastAPI.api_route)
-    def api_route(self, *args: Any, **kwargs: Any):
-        route = super().api_route(*args, **kwargs)
-        self.enrich_swagger()
-        return route
-
-    @same_definition_as_in(FastAPI.add_api_websocket_route)
-    def add_api_websocket_route(self, *args: Any, **kwargs: Any):  # pragma: no cover
-        route = super().add_api_websocket_route(*args, **kwargs)
-        self.enrich_swagger()
-        return route
-
-    @same_definition_as_in(FastAPI.websocket)
-    def websocket(self, *args: Any, **kwargs: Any):  # pragma: no cover
-        route = super().websocket(*args, **kwargs)
-        self.enrich_swagger()
-        return route
 
     def add_unversioned_routers(self, *routers: APIRouter):
         for router in routers:
             self.router.include_router(router)
-        self.enrich_swagger()
 
     @deprecated("Use add add_unversioned_routers instead")
     def add_unversioned_routes(self, *routes: Route):

--- a/tests/_resources/versioned_app/app.py
+++ b/tests/_resources/versioned_app/app.py
@@ -25,6 +25,7 @@ versioned_app = Cadwyn(versions=VersionBundle(Version(date(2022, 11, 16))), life
 versioned_app.add_header_versioned_routers(v2021_01_01_router, header_value="2021-01-01")
 versioned_app.add_header_versioned_routers(v2022_01_02_router, header_value="2022-02-02")
 versioned_app.add_unversioned_routers(webhooks_router)
+versioned_app.enrich_swagger()
 
 versioned_app_with_custom_api_version_var = Cadwyn(
     versions=VersionBundle(Version(date(2022, 11, 16))), lifespan=lifespan, api_version_var=ContextVar("My api version")

--- a/tests/_resources/versioned_app/app.py
+++ b/tests/_resources/versioned_app/app.py
@@ -20,6 +20,7 @@ async def lifespan(app: FastAPI):
     # to run the lifespan scope during test runs
     yield  # pragma: no cover
 
+
 lifespan_app = Cadwyn(versions=VersionBundle(Version(date(2022, 11, 16))), lifespan=lifespan)
 versioned_app = Cadwyn(versions=VersionBundle(Version(date(2022, 11, 16))))
 versioned_app.add_header_versioned_routers(v2021_01_01_router, header_value="2021-01-01")

--- a/tests/_resources/versioned_app/app.py
+++ b/tests/_resources/versioned_app/app.py
@@ -20,12 +20,11 @@ async def lifespan(app: FastAPI):
     # to run the lifespan scope during test runs
     yield  # pragma: no cover
 
-
-versioned_app = Cadwyn(versions=VersionBundle(Version(date(2022, 11, 16))), lifespan=lifespan)
+lifespan_app = Cadwyn(versions=VersionBundle(Version(date(2022, 11, 16))), lifespan=lifespan)
+versioned_app = Cadwyn(versions=VersionBundle(Version(date(2022, 11, 16))))
 versioned_app.add_header_versioned_routers(v2021_01_01_router, header_value="2021-01-01")
 versioned_app.add_header_versioned_routers(v2022_01_02_router, header_value="2022-02-02")
 versioned_app.add_unversioned_routers(webhooks_router)
-versioned_app.enrich_swagger()
 
 versioned_app_with_custom_api_version_var = Cadwyn(
     versions=VersionBundle(Version(date(2022, 11, 16))), lifespan=lifespan, api_version_var=ContextVar("My api version")
@@ -35,7 +34,8 @@ versioned_app_with_custom_api_version_var.add_header_versioned_routers(v2022_01_
 versioned_app_with_custom_api_version_var.add_unversioned_routers(webhooks_router)
 
 client = TestClient(versioned_app, raise_server_exceptions=False, headers=BASIC_HEADERS)
-client_without_headers = TestClient(versioned_app)
+with TestClient(versioned_app) as client_without_headers:
+    pass
 client_without_headers_and_with_custom_api_version_var = TestClient(versioned_app_with_custom_api_version_var)
 
 if __name__ == "__main__":

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -47,6 +47,7 @@ def test__header_routing_fastapi_init__changing_openapi_url__docs_still_return_2
     client = TestClient(app)
     app.add_header_versioned_routers(v2021_01_01_router, header_value="2021-01-01")
     app.add_header_versioned_routers(v2022_01_02_router, header_value="2022-02-02")
+    app.enrich_swagger()
     assert client.get("/openpapi?version=2021-01-01").status_code == 200
     assert client.get("/openapi.json?version=2021-01-01").status_code == 404
 

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -14,9 +14,9 @@ from tests._resources.versioned_app.app import (
     client_without_headers,
     client_without_headers_and_with_custom_api_version_var,
     lifespan,
+    lifespan_app,
     v2021_01_01_router,
     v2022_01_02_router,
-    versioned_app,
 )
 
 
@@ -44,12 +44,11 @@ def test__header_routing_fastapi_init__openapi_passing_nulls__should_not_add_ope
 
 def test__header_routing_fastapi_init__changing_openapi_url__docs_still_return_200():
     app = Cadwyn(versions=VersionBundle(Version(date(2022, 11, 16))), openapi_url="/openpapi")
-    client = TestClient(app)
     app.add_header_versioned_routers(v2021_01_01_router, header_value="2021-01-01")
     app.add_header_versioned_routers(v2022_01_02_router, header_value="2022-02-02")
-    app.enrich_swagger()
-    assert client.get("/openpapi?version=2021-01-01").status_code == 200
-    assert client.get("/openapi.json?version=2021-01-01").status_code == 404
+    with TestClient(app) as client:
+        assert client.get("/openpapi?version=2021-01-01").status_code == 200
+        assert client.get("/openapi.json?version=2021-01-01").status_code == 404
 
 
 def test__header_routing_fastapi_add_header_versioned_routers__apirouter_is_empty__version_should_not_have_any_routes():
@@ -145,4 +144,4 @@ def test__empty_root():
 
 
 def test__lifespan_context_exists():
-    assert versioned_app.router.lifespan_context is lifespan
+    assert lifespan_app.router.lifespan_context is lifespan


### PR DESCRIPTION
This pull request:

- adds enrich_swagger() method to the startup event handler.
- cleans up unnecessary calls to enrich_swagger()
- fixes tests

Initially, only three tests failed because lifespan events don't work for tests, and now we need to manually call the enrich_swagger() in tests, after manipulate the routes.