### PR TITLE
Add root path to servers list of OpenAPI spec.

### DIFF
--- a/cadwyn/applications.py
+++ b/cadwyn/applications.py
@@ -269,6 +269,13 @@ class Cadwyn(FastAPI):
         else:
             raise not_found_error
 
+        # Add root path to servers when mounted as sub-app or proxy is used
+        urls = (server_data.get("url") for server_data in self.servers)
+        server_urls = {url for url in urls if url}
+        root_path = self._extract_root_path(req)
+        if root_path and root_path not in server_urls and self.root_path_in_servers:
+            self.servers.insert(0, {"url": root_path})
+
         return JSONResponse(
             get_openapi(
                 title=self.title,

--- a/cadwyn/applications.py
+++ b/cadwyn/applications.py
@@ -327,7 +327,7 @@ class Cadwyn(FastAPI):
 
     def _render_docs_dashboard(self, req: Request, docs_url: str):
         base_host = str(req.base_url).rstrip("/")
-        root_path = req.scope.get("root_path", "")
+        root_path = self._extract_root_path(req)
         base_url = base_host + root_path
         table = {version: f"{base_url}{docs_url}?version={version}" for version in self.router.sorted_versions}
         if self._there_are_public_unversioned_routes():

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -184,6 +184,16 @@ def test__get_openapi__nonexisting_version__error():
     assert resp.json() == {"detail": "OpenApi file of with version `2023-01-01` not found"}
 
 
+def test__get_openapi__with_mounted_app__should_include_root_path_in_servers():
+    root_app = FastAPI()
+    root_app.mount("/my_api", Cadwyn(changelog_url=None, versions=VersionBundle(Version(date(2022, 11, 16)))))
+    client = TestClient(root_app)
+
+    resp = client.get("/my_api/openapi.json?version=2022-11-16")
+    servers = resp.json()["servers"]
+    assert "/my_api" in [server["url"] for server in servers]
+
+
 def test__get_docs__without_unversioned_routes__should_return_all_versioned_doc_urls():
     app = Cadwyn(changelog_url=None, versions=VersionBundle(Version(date(2022, 11, 16))))
     app.add_header_versioned_routers(v2021_01_01_router, header_value="2021-01-01")


### PR DESCRIPTION
Normally, FastAPI includes the root path in the OpenAPI spec if not contained in the user defined servers list.
This helps to support sub-apps and APIs behind a reverse proxy.
This PR implements that behavior for cadwyn.