### PR TITLE
Add summary to generated openapi spec

### DIFF
--- a/cadwyn/applications.py
+++ b/cadwyn/applications.py
@@ -275,6 +275,7 @@ class Cadwyn(FastAPI):
                 version=formatted_version,
                 openapi_version=self.openapi_version,
                 description=self.description,
+                summary=self.summary,
                 terms_of_service=self.terms_of_service,
                 contact=self.contact,
                 license_info=self.license_info,


### PR DESCRIPTION
OpenAPI spec is missing summary field from `Cadwyn()` constructor.

Fixed