### PR TITLE
Resolve some warnings

### DIFF
--- a/cadwyn/applications.py
+++ b/cadwyn/applications.py
@@ -358,8 +358,9 @@ class Cadwyn(FastAPI):
         if self._there_are_public_unversioned_routes():
             table |= {"unversioned": f"{base_url}{docs_url}?version=unversioned"}
         return self._templates.TemplateResponse(
+            req,
             "docs.html",
-            {"request": req, "table": table},
+            {"table": table},
         )
 
     def add_header_versioned_routers(

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1,3 +1,4 @@
+import contextlib
 from datetime import date
 
 import pytest
@@ -115,18 +116,17 @@ def test__lifespan_async():
     async def hello_world(request: Request):
         return PlainTextResponse("hello, world")
 
-    async def run_startup():
+    @contextlib.asynccontextmanager
+    async def lifespan(app):
         nonlocal startup_complete
         startup_complete = True
-
-    async def run_shutdown():
+        yield
         nonlocal shutdown_complete
         shutdown_complete = True
 
     app = Cadwyn(
         versions=VersionBundle(Version(date(2022, 11, 16))),
-        on_startup=[run_startup],
-        on_shutdown=[run_shutdown],
+        lifespan=lifespan,
     )
     app.add_route("/v1/", hello_world)
 

--- a/tests/test_schema_generation/test_schema_field.py
+++ b/tests/test_schema_generation/test_schema_field.py
@@ -74,7 +74,7 @@ def test__field_existed_as__extras_are_added(create_runtime_schemas: CreateRunti
             .field("foo")
             .existed_as(
                 type=int,
-                info=Field(deflolbtt="hewwo"),  # pyright: ignore[reportCallIssue]
+                info=Field(json_schema_extra={"deflolbtt": "hewwo"}),
             ),
         )
     )


### PR DESCRIPTION
This resolves three categories of `DeprecationWarning` [currently getting thrown in CI](https://github.com/zmievsa/cadwyn/actions/runs/12246449552/job/34162349723#step:4:44):

* A starlette templating warning
* A starlette routing warning
* A pydantic fields warning

There are two other categories, but I won't be able to get to them quickly.

----

Once all warnings are resolved, I recommend adding the following configuration to `pyproject.toml`:

```toml
[tool.pytest.ini_options]
filterwarnings = [
    "error",
]
```

This will escalate warnings to errors so that CI (and local testing) can flag potential upcoming issues.