### PR TITLE
Update `actions/(upload|download)-artifact` to v4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,10 +42,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - run: uv run coverage run --source=. --parallel-mode -m pytest tests
       - name: Upload coverage results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: matrix.os == 'ubuntu-latest' # Cross-platform coverage combination doesn't work
         with:
-          name: main-tests-coverage-results
+          name: coverage-results-${{ matrix.python-version }}
           path: coverage/
   Tutorial-tests:
     runs-on: ubuntu-latest
@@ -60,24 +60,20 @@ jobs:
       - run: pip install pytest coverage dirty-equals
       - run: coverage run --source=. --parallel-mode -m pytest docs_src
       - name: Upload coverage results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: docs-tests-coverage-results
+          name: coverage-results-docs
           path: coverage/
   Coverage:
     needs: [Tests, Tutorial-tests]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Download main tests coverage info
-        uses: actions/download-artifact@v3
+      - name: Download coverage info
+        uses: actions/download-artifact@v4
         with:
-          name: main-tests-coverage-results
-          path: coverage/
-      - name: Download docs tests coverage info
-        uses: actions/download-artifact@v3
-        with:
-          name: docs-tests-coverage-results
+          name: coverage-results-*
+          merge-multiple: true
           path: coverage/
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
> [!NOTE]
>
> This resolves a warning currently thrown in CI ([recent example](https://github.com/zmievsa/cadwyn/actions/runs/12256876257)):
>
> ![image](https://github.com/user-attachments/assets/4ff8ee98-855a-4116-91b5-e2fccb75e179)


`actions/upload-artifact` v3 and `actions/download-artifact` v3 [will be disabled on 2025-01-31](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/).

The only change from v3 to v4 that affects this workflow is that artifacts with the same name can only be overwritten, so the artifact names must now be unique.

Merging now happens at download, not at upload, so this commit modifies the Python and docs test artifact names to share the same prefix and downloads them all in one shot.