### PR TITLE
Update old action versions

### DIFF
--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -14,11 +14,11 @@ jobs:
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.x
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           key: mkdocs-material-${{ env.cache_id }}
           path: .cache


### PR DESCRIPTION
This resolves warnings in CI that two actions use Node.js 16 and must be upgraded to versions that use Node.js 20 ([recent example](https://github.com/zmievsa/cadwyn/actions/runs/8683445478)).

Would you be interested in a PR to configure Dependabot to monitor for updates to action versions on a monthly basis?