### PR TITLE
Update the blacken-docs `black` dependency to the latest version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,11 +25,11 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/adamchainz/blacken-docs
-    rev: "1.19.1" # replace with latest tag on GitHub
+    rev: "1.19.1"
     hooks:
       - id: blacken-docs
         additional_dependencies:
-          - black==22.12.0
+          - black==24.10.0
         args: ["--line-length=80", "--target-version=py310", "--skip-errors"]
 
   - repo: https://github.com/igorshubovych/markdownlint-cli

--- a/docs/concepts/endpoint_migrations.md
+++ b/docs/concepts/endpoint_migrations.md
@@ -9,8 +9,7 @@ If you had an endpoint in old version but do not have it in a new one, you must 
 ```python
 @router.only_exists_in_older_versions
 @router.get("/users/{user_id}")
-async def my_old_endpoint():
-    ...
+async def my_old_endpoint(): ...
 ```
 
 and then define it as existing in one of the older versions:

--- a/docs/concepts/version_changes.md
+++ b/docs/concepts/version_changes.md
@@ -302,6 +302,7 @@ from cadwyn import (
 )
 from users import BaseUser, UserCreateRequest, UserResource
 
+
 # THIS IS AN EXAMPLE OF A BAD MIGRATION
 class RemoveTaxIDEndpoints(VersionChange):
     description = "Users now have `address` field instead of `addresses`"

--- a/docs/quickstart/setup.md
+++ b/docs/quickstart/setup.md
@@ -13,9 +13,11 @@ Cadwyn is built around FastAPI and supports all of its functionality out of the 
 
 First, let's set up the most basic versioned app possible:
 
+<!-- blacken-docs:off -->
 ```python
 {!> ../docs_src/quickstart/setup/block002.py !}
 ```
+<!-- blacken-docs:on -->
 
 and run it using:
 

--- a/docs/quickstart/tutorial.md
+++ b/docs/quickstart/tutorial.md
@@ -18,9 +18,11 @@ Here is an initial API setup where the User has a single address. We will be imp
 
 The first API you come up with usually doesn't require more than one address -- why bother?
 
+<!-- blacken-docs:off -->
 ```python
 {!> ../docs_src/quickstart/tutorial/block001.py !}
 ```
+<!-- blacken-docs:on -->
 
 If we visit `/docs`, we will see the following dashboard:
 
@@ -32,9 +34,11 @@ The app is ready to be used. Every time you would like to call its endpoints, yo
 
 During our development, we have realized that the initial API design was wrong and that addresses should have always been a list because the user wants to have multiple addresses to choose from so now we have to change the type of the "address" field to the list of strings.
 
+<!-- blacken-docs:off -->
 ```python hl_lines="2 4 15 20 30 39"
 {!> ../docs_src/quickstart/tutorial/block002.py !}
 ```
+<!-- blacken-docs:on -->
 
 Now every user of ours will now have their API integration broken. To prevent that, we have to introduce API versioning. There aren't many methods of doing that. Most of them force you to either duplicate your schemas, your endpoints, or your entire app instance. And it makes sense, really: duplication is the only way to make sure that you will not break old versions with your new versions; the bigger the piece you duplicating -- the safer. Of course, the safest being duplicating the entire app instance and even having a separate database. But that is expensive and makes it either impossible to make breaking changes often or to support many versions. As a result, either you need infinite resources, very long development cycles, or your users will need to often migrate from version to version.
 
@@ -56,9 +60,11 @@ To fix the old integrations of our clients, we need to add back the `2000-01-01`
 
 For every endpoint whose `response_model` is `UserResource`, this migration will convert the list of addresses back to a single address when migrating to the previous version. Our goal is to have an app of [HEAD version](../concepts/version_changes.md#headversion) and to describe what older versions looked like in comparison to it. That way the old versions are frozen in migrations and you can **almost** safely forget about them.
 
+<!-- blacken-docs:off -->
 ```python hl_lines="8-9 12 14-16 45-66"
 {!> ../docs_src/quickstart/tutorial/block003.py !}
 ```
+<!-- blacken-docs:on -->
 
 See how we are popping the first address from the list? This is only guaranteed to be possible because we specified earlier that `min_length` for `addresses` must be `1`. If we didn't, then the user would be able to create a user in a newer version that would be impossible to represent in the older version. I.e. If anyone tried to get that user from the older version, they would get a `ResponseValidationError` because the user wouldn't have data for a mandatory `address` field. You need to always keep in mind that API versioning is only for versioning your **API**, your interface. Your versions must still be completely compatible in terms of data. If they are not, then you are versioning your data and you should really go with a separate app instance. Otherwise, your users will have a hard time migrating back and forth between API versions and so many unexpected errors.
 


### PR DESCRIPTION
This commit makes the following changes:

* Update the blacken-docs `black` dependency to the latest version
* Run `pre-commit run -a`
* Disable blacken-docs for several Markdown include directives that blacken-docs doesn't know to ignore and fails to parse
* Remove an unnecessary comment

I spotted this opportunity while working on adding a tox config file.