### PR TITLE
Fix a key name change for `actions/download-artifact@v4`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,7 @@ on:
     branches: [main, 3.x.x]
     types: [opened, synchronize]
     paths:
+      - ".github/workflows/ci.yaml"  # self
       - "**.py"
       - "**.toml"
       - "**.lock"
@@ -72,7 +73,7 @@ jobs:
       - name: Download coverage info
         uses: actions/download-artifact@v4
         with:
-          name: coverage-results-*
+          pattern: coverage-results-*
           merge-multiple: true
           path: coverage/
       - uses: actions/setup-python@v5


### PR DESCRIPTION
I overlooked this change in #235, and that PR didn't change files that would have triggered the CI test suite to run.

So, in addition, this PR modifies `ci.yaml` so that changes to that file trigger the workflow, too.