### PR TITLE
Introduce tox

### DIFF
--- a/.github/actions/setup-python-uv/action.yaml
+++ b/.github/actions/setup-python-uv/action.yaml
@@ -8,7 +8,7 @@ inputs:
   uv-version:
     description: "The uv version to set up"
     required: true
-    default: "0.4.18"
+    default: "0.5.8"
 
 runs:
   using: "composite"
@@ -16,12 +16,12 @@ runs:
     - uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python-version }}
-    - uses: astral-sh/setup-uv@v3
+    - uses: astral-sh/setup-uv@v5
       with:
         version: ${{ inputs.uv-version }}
         enable-cache: true
         cache-dependency-glob: "uv.lock"
     - run: |
         uv sync --frozen --all-extras --dev
-        echo "$(pwd)/.venv/bin" >> $GITHUB_PATH
+        uv pip install --system tox tox-uv
       shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,13 +41,13 @@ jobs:
       - uses: ./.github/actions/setup-python-uv
         with:
           python-version: ${{ matrix.python-version }}
-      - run: uv run coverage run --source=. --parallel-mode -m pytest tests
+      - run: tox run -e py
       - name: Upload coverage results
         uses: actions/upload-artifact@v4
         if: matrix.os == 'ubuntu-latest' # Cross-platform coverage combination doesn't work
         with:
           name: coverage-results-${{ matrix.python-version }}
-          path: coverage/
+          path: .coverage*
   Tutorial-tests:
     runs-on: ubuntu-latest
     name: Tutorial tests
@@ -58,13 +58,15 @@ jobs:
           python-version: "3.10"
       - name: Install cadwyn with instructions from docs
         run: sh docs_src/quickstart/setup/block001.sh
-      - run: pip install pytest coverage dirty-equals
-      - run: coverage run --source=. --parallel-mode -m pytest docs_src
+      - run: |
+          pip install uv
+          uv pip install --system pytest coverage dirty-equals
+          coverage run -m pytest docs_src
       - name: Upload coverage results
         uses: actions/upload-artifact@v4
         with:
           name: coverage-results-docs
-          path: coverage/
+          path: .coverage*
   Coverage:
     needs: [Tests, Tutorial-tests]
     runs-on: ubuntu-latest
@@ -75,32 +77,40 @@ jobs:
         with:
           pattern: coverage-results-*
           merge-multiple: true
-          path: coverage/
+          path: .
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
-      - run: pip install 'coverage[toml]'
-      - run: coverage combine
-      - run: coverage xml
+      - run: |
+          pip install uv
+          uv pip install --system tox tox-uv
+          tox run -e coverage_report-ci
       - name: Upload to Codecov
         uses: codecov/codecov-action@v4
         env:
           fail_ci_if_error: true
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      - run: coverage report --fail-under=100 --show-missing
 
   Lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pre-commit/action@v3.0.0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - run: |
+          python -m pip install uv
+          uv pip install --system pre-commit pre-commit-uv
+          pre-commit run --all-files
 
   Typecheck:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-python-uv
-
-      - uses: jakebailey/pyright-action@v1
         with:
-          pylance-version: latest-release
+          # When this version is updated,
+          # update the pyright `base_python` version in `tox.ini`, too.
+          python-version: "3.10"
+      - run: |
+          tox run -e pyright

--- a/.github/workflows/daily_tests.yaml
+++ b/.github/workflows/daily_tests.yaml
@@ -21,7 +21,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: uv sync --refresh --all-extras --dev --upgrade
-      - run: pytest .
+      - run: tox run -e py
       - uses: jakebailey/pyright-action@v1
         with:
           pylance-version: latest-release

--- a/.github/workflows/validate_links.yaml
+++ b/.github/workflows/validate_links.yaml
@@ -23,12 +23,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-python-uv
       - run: |
-          OUTPUT=$(uv run mkdocs build 2>&1)
-          echo "$OUTPUT"
-
-          if echo "$OUTPUT" | grep -q "ERROR"; then
-              exit 1
-          fi
+          tox run -e docs
 
   markdown-link-check:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,4 @@ lint:
 	pre-commit run --all-files
 
 test:
-	rm -r coverage; \
-	uv run coverage run --source=. -m pytest .; \
-	uv run coverage combine; \
-	uv run coverage report --fail-under=100 --show-missing;
+	uv run --with tox --with tox-uv tox

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,8 @@ dev-dependencies = [
     "pytest-cov >=4.0.0",
     "dirty-equals >=0.6.0",
     "uvicorn ~=0.23.0",
+    # type checking
+    "pyright>=1.1.390",
     # docs
     "mkdocs >=1.5.2",
     "mkdocs-material >=9.3.1",
@@ -99,6 +101,7 @@ parallel = true
 branch = true
 
 [tool.coverage.report]
+fail_under = 100
 skip_covered = true
 skip_empty = true
 # Taken from https://coverage.readthedocs.io/en/7.1.0/excluding.html#advanced-exclusion

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,3 @@
-import sys
 import textwrap
 
 import pytest
@@ -9,7 +8,7 @@ from cadwyn.__main__ import app
 
 
 def code(c: str) -> str:
-    return textwrap.dedent(c.strip())
+    return "\n".join(line.rstrip() for line in textwrap.dedent(c.strip()).splitlines())
 
 
 def test__render_module():
@@ -70,14 +69,7 @@ def test__render_model__with_syntax_highlighting():  # pragma: no cover
         ],
     )
     assert result.exit_code == 0
-
-    if sys.platform.startswith("win32"):
-        # Windows rendering is weird
-        return
-
-    assert code(result.stdout) == (
-        "1 class A(BaseModel):                                                         \n  2     pass"
-    )
+    assert code(result.stdout) == "1 class A(BaseModel):\n  2     pass"
 
 
 @pytest.mark.parametrize("arg", ["-V", "--version"])

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,61 @@
+[tox]
+envlist =
+    coverage_erase
+    # When updating Python versions, use search-and-replace
+    # against the entire list of of versions
+    # to ensure consistency throughout this file.
+    py{3.13, 3.12, 3.11, 3.10}
+    coverage_report
+    docs
+    pyright
+
+
+[testenv]
+runner = uv-venv-lock-runner
+with_dev = true
+extras =
+    standard
+package = wheel
+wheel_build_env = build_wheel
+depends =
+    py{3.13, 3.12, 3.11, 3.10}: coverage_erase
+commands = coverage run -m pytest {posargs}
+
+
+[testenv:coverage_erase]
+skip_install = true
+commands = coverage erase
+
+
+[testenv:coverage_report]
+skip_install = true
+depends =
+    py{3.13, 3.12, 3.11, 3.10}
+commands_pre =
+    # Ignore the exit code of `coverage combine`
+    # (in case the reports are already combined).
+    - coverage combine
+commands =
+    coverage report --show-missing
+
+
+[testenv:coverage_report-ci]
+# Inherit everything from the `coverage_report` environment,
+# but generate an XML report and ignore exit codes.
+base = coverage_report
+commands =
+    - coverage xml --fail-under=0
+    - coverage report --show-missing
+
+
+[testenv:docs]
+base_python = py3.10
+skip_install = true
+commands = mkdocs build --strict
+
+
+[testenv:pyright]
+# When the Python version is updated here,
+# update the version used in the CI `Typecheck` job, too.
+base_python = py3.10
+commands = pyright

--- a/uv.lock
+++ b/uv.lock
@@ -109,6 +109,7 @@ dev = [
     { name = "mkdocs-material" },
     { name = "mkdocs-simple-hooks" },
     { name = "pdbpp" },
+    { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-fixture-classes" },
@@ -142,6 +143,7 @@ dev = [
     { name = "mkdocs-material", specifier = ">=9.3.1" },
     { name = "mkdocs-simple-hooks", specifier = ">=0.1.5" },
     { name = "pdbpp", specifier = "~=0.10.3" },
+    { name = "pyright", specifier = ">=1.1.390" },
     { name = "pytest", specifier = ">=7.2.1" },
     { name = "pytest-cov", specifier = ">=4.0.0" },
     { name = "pytest-fixture-classes", specifier = ">=1.0.3" },
@@ -784,6 +786,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314 },
+]
+
+[[package]]
 name = "packaging"
 version = "24.2"
 source = { registry = "https://pypi.org/simple" }
@@ -973,6 +984,19 @@ name = "pyrepl"
 version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/05/1b/ea40363be0056080454cdbabe880773c3c5bd66d7b13f0c8b8b8c8da1e0c/pyrepl-0.9.0.tar.gz", hash = "sha256:292570f34b5502e871bbb966d639474f2b57fbfcd3373c2d6a2f3d56e681a775", size = 48744 }
+
+[[package]]
+name = "pyright"
+version = "1.1.390"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/42/1e0392f35dd275f9f775baf7c86407cef7f6a0d9b8e099a93e5422a7e571/pyright-1.1.390.tar.gz", hash = "sha256:aad7f160c49e0fbf8209507a15e17b781f63a86a1facb69ca877c71ef2e9538d", size = 21950 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/20/3f492ca789fb17962ad23619959c7fa642082621751514296c58de3bb801/pyright-1.1.390-py3-none-any.whl", hash = "sha256:ecebfba5b6b50af7c1a44c2ba144ba2ab542c227eb49bc1f16984ff714e0e110", size = 18579 },
+]
 
 [[package]]
 name = "pytest"


### PR DESCRIPTION
This PR introduces a tox configuration that standardizes all of the project testing using tox.

It does not eliminate the Makefile, but pushes all of the work into the tox configuration so that all platforms (whether Linux, macOS, or Windows) and runner environments (whether locally or in CI) are running the test suite in the same way.

Commit highlights
-----------------

* Add pyright as a dev dependency.
* Add tox configurations that run pyright and mkdocs on Python 3.10.

  This matches the Python version currently used in CI.

* Add a tox config to run the test suite against Python 3.10+.
* Fix a CLI rendering test on Windows.
* Update CI to install tox and tox-uv.
* Use tox to execute the test suite in CI.

  This ensures that CI and local testing mirror each other.

Decisions made
--------------

* tox-uv (and thus, tox) is not added as a dev dependency.

  tox-uv depends on uv, which would add uv
  as a locked dependency in `uv.lock`.
  This seems circular, so tox-uv is not a dev dependency.

* The mkdocs ``--strict`` mode appears to work similar to
  the existing architecture in CI, which greps CLI output
  for the would "ERROR".

  However, it may be that ``--strict`` mode fails fast,
  so this might not be strictly equivalent to output grepping.

* Coverage files are no longer stored in `coverage/`;
  they are instead stored in `.coverage*` files.

  This is not a deliberate decision, but a side-effect.

Closes #234 