### PR TITLE
use head route path instead of path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Please follow [the Keep a Changelog standard](https://keepachangelog.com/en/1.0.
 
 ## [Unreleased]
 
+### Fixed
+
+* Fix response migrations if response migration is defined by the URI and coincides with the endpoint migration.
+
 ## [4.5.0]
 
 ### Added

--- a/cadwyn/schema_generation.py
+++ b/cadwyn/schema_generation.py
@@ -171,7 +171,7 @@ def migrate_response_body(
         response,
         current_version=version,
         head_response_model=latest_response_model,
-        path="\0\0\0",
+        head_route_path="\0\0\0",
         method="GET",
     )
 

--- a/cadwyn/structure/versions.py
+++ b/cadwyn/structure/versions.py
@@ -393,7 +393,7 @@ class VersionBundle:
         response_info: ResponseInfo,
         current_version: VersionDate,
         head_response_model: type[BaseModel],
-        path: str,
+        head_route_path: str,
         method: str,
     ) -> ResponseInfo:
         for v in self.versions:
@@ -407,7 +407,7 @@ class VersionBundle:
                         version_change.alter_response_by_schema_instructions[head_response_model]
                     )
 
-                if path in version_change.alter_response_by_path_instructions:
+                if head_route_path in version_change.alter_response_by_path_instructions:
                     for instruction in version_change.alter_response_by_path_instructions[path]:
                         if method in instruction.methods:  # pragma: no branch # Safe branch to skip
                             migrations_to_apply.append(instruction)  # noqa: PERF401
@@ -563,7 +563,7 @@ class VersionBundle:
             response_info,
             api_version,
             head_route.response_model,
-            route.path,
+            head_route.path,
             method,
         )
         if isinstance(response_or_response_body, FastapiResponse):


### PR DESCRIPTION
Since the endpoint is updated before the response migration is applied, response migration is skipped if it coincides with the endpoint migration. This PR suggests using head route path in response migrations.