### PR TITLE
Update minimum FastAPI version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP",
 ]
 dependencies = [
-    "fastapi >=0.112.3",
+    "fastapi >=0.112.4",
     "starlette >=0.30.0",
     "pydantic >=2.0.0",
     "jinja2 >=3.1.2",

--- a/uv.lock
+++ b/uv.lock
@@ -138,7 +138,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "backports-strenum", marker = "python_full_version < '3.11'", specifier = ">=1.3.1,<2" },
-    { name = "fastapi", specifier = ">=0.112.3" },
+    { name = "fastapi", specifier = ">=0.112.4" },
     { name = "fastapi", extras = ["standard"], marker = "extra == 'standard'", specifier = ">=0.112.3" },
     { name = "issubclass", specifier = ">=0.1.2" },
     { name = "jinja2", specifier = ">=3.1.2" },


### PR DESCRIPTION
`_embed_body_fields` was only introduced in 0.112.4.

