### PR TITLE
feat: Auto-populate VersionChange description from docstring

### DIFF
--- a/cadwyn/structure/versions.py
+++ b/cadwyn/structure/versions.py
@@ -73,6 +73,7 @@ else:
 
 
 class VersionChange:
+    @deprecated("Explicitly setting 'description' is deprecated. Use the class docstring instead.")
     description: ClassVar[str] = Sentinel
     is_hidden_from_changelog: bool = False
     instructions_to_migrate_to_previous_version: ClassVar[Sequence[PossibleInstructions]] = Sentinel
@@ -147,7 +148,7 @@ class VersionChange:
         if cls.description is Sentinel or not cls.description or not cls.description.strip():
             raise CadwynStructureError(
                 f"Version change description is not set on '{cls.__name__}' but is required. "
-                "It can be set via `description = '...'` or via the class docstring."
+                "Please set it via the class docstring."
             )
         if cls.instructions_to_migrate_to_previous_version is Sentinel:
             raise CadwynStructureError(

--- a/cadwyn/structure/versions.py
+++ b/cadwyn/structure/versions.py
@@ -94,6 +94,9 @@ class VersionChange:
 
         if _abstract:
             return
+        # If description is not set, use __doc__
+        if cls.description is Sentinel:
+            cls.description = cls.__doc__
         cls._validate_subclass()
         cls._extract_list_instructions_into_correct_containers()
         cls._extract_body_instructions_into_correct_containers()
@@ -141,9 +144,10 @@ class VersionChange:
 
     @classmethod
     def _validate_subclass(cls):
-        if cls.description is Sentinel:
+        if cls.description is Sentinel or not cls.description or not cls.description.strip():
             raise CadwynStructureError(
-                f"Version change description is not set on '{cls.__name__}' but is required.",
+                f"Version change description is not set on '{cls.__name__}' but is required. "
+                "It can be set via `description = '...'` or via the class docstring."
             )
         if cls.instructions_to_migrate_to_previous_version is Sentinel:
             raise CadwynStructureError(

--- a/docs/concepts/version_changes.md
+++ b/docs/concepts/version_changes.md
@@ -20,7 +20,7 @@ from cadwyn import VersionChange, endpoint
 
 
 class RemoveTaxIDEndpoints(VersionChange):
-    description = "Remove `GET /v1/tax_ids` and `POST /v1/tax_ids` endpoints"
+    """Remove `GET /v1/tax_ids` and `POST /v1/tax_ids` endpoints"""
     instructions_to_migrate_to_previous_version = (
         endpoint("/v1/tax_ids", ["GET", "POST"]).existed,
     )
@@ -110,7 +110,11 @@ versions = VersionBundle(
 
 ### VersionChange.description
 
-The description field of your version change must be even more detailed. In fact, it is intended to be the **name** and the **summary** of the version change for your clients. It must clearly state to you clients **what happened** and **why**. So you need to make it grammatically correct, detailed, concrete, and written for humans. Note that you do not have to use a strict machine-readable format -- it is a portion of documentation, not a set of instructions. Let's take [Stripe's description](https://stripe.com/blog/api-versioning) to one of their version changes as an example:
+The description of your version change is provided via its class docstring. It must be detailed and is intended to be the **name** and the **summary** of the version change for your clients. It must clearly state to your clients **what happened** and **why**. So you need to make it grammatically correct, detailed, concrete, and written for humans. Note that you do not have to use a strict machine-readable format -- it is a portion of documentation, not a set of instructions.
+
+*Note: Previously, the description could be set via a `description` class attribute. This method is now deprecated in favor of using the class docstring.*
+
+Let's take [Stripe's description](https://stripe.com/blog/api-versioning) to one of their version changes as an example:
 
 ```md
 Event objects (and webhooks) will now render `request` subobject that contains a request ID and idempotency key instead of just a string request ID.

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -72,12 +72,58 @@ class TestVersionChange:
         with pytest.raises(
             CadwynStructureError,
             match=re.escape(
-                "Version change description is not set on 'DummySubClass' but is required.",
+                "Version change description is not set on 'DummySubClass' but is required. "
+                "It can be set via `description = '...'` or via the class docstring.",
             ),
         ):
 
             class DummySubClass(VersionChange):
                 instructions_to_migrate_to_previous_version = []
+
+    def test__description__set_via_docstring(self):
+        class DummySubClassWithDocstring(VersionChange):
+            """This is a docstring description."""
+
+            instructions_to_migrate_to_previous_version = []
+
+        assert DummySubClassWithDocstring.description == "This is a docstring description."
+
+    def test__description__empty_docstring__should_raise_error(self):
+        with pytest.raises(
+            CadwynStructureError,
+            match=re.escape(
+                "Version change description is not set on 'DummySubClassWithEmptyDocstring' but is required. "
+                "It can be set via `description = '...'` or via the class docstring.",
+            ),
+        ):
+
+            class DummySubClassWithEmptyDocstring(VersionChange):
+                """"""
+
+                instructions_to_migrate_to_previous_version = []
+
+    def test__description__whitespace_docstring__should_raise_error(self):
+        with pytest.raises(
+            CadwynStructureError,
+            match=re.escape(
+                "Version change description is not set on 'DummySubClassWithWhitespaceDocstring' but is required. "
+                "It can be set via `description = '...'` or via the class docstring.",
+            ),
+        ):
+
+            class DummySubClassWithWhitespaceDocstring(VersionChange):
+                """   """
+
+                instructions_to_migrate_to_previous_version = []
+
+    def test__description__explicit_description_overrides_docstring(self):
+        class DummySubClassWithDocstringAndDescription(VersionChange):
+            """This is a docstring."""
+
+            description = "This is an explicit description."
+            instructions_to_migrate_to_previous_version = []
+
+        assert DummySubClassWithDocstringAndDescription.description == "This is an explicit description."
 
     def test__instructions_to_migrate_to_previous_version__not_set__should_raise_error(self):
         with pytest.raises(


### PR DESCRIPTION
If a `VersionChange` subclass does not explicitly define a `description` attribute, its docstring (`__doc__`) will now be used as the description.

The `_validate_subclass` method in `VersionChange` has been updated to raise a `CadwynStructureError` if the description (whether explicitly set or derived from the docstring) is empty or consists only of whitespace. The error message has also been clarified to guide you on how to set the description.

New tests have been added to `tests/test_structure.py` to verify:
- Description is correctly populated from the docstring.
- An error is raised if both explicit description and docstring are missing or empty.
- An explicit `description` attribute correctly overrides the docstring.