### PR TITLE
Remove duplicate pygrep-hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,11 +13,6 @@ repos:
       - id: trailing-whitespace
       - id: detect-private-key
 
-  - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.10.0
-    hooks:
-      - id: python-check-blanket-noqa
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.10
     hooks:


### PR DESCRIPTION
PGH rule is already active in ruff config

https://docs.astral.sh/ruff/rules/#pygrep-hooks-pgh