### PR TITLE
Assume non-BaseModel annotations are union

### DIFF
--- a/cadwyn/changelogs.py
+++ b/cadwyn/changelogs.py
@@ -2,7 +2,7 @@ import copy
 import sys
 from enum import auto
 from logging import getLogger
-from typing import Any, Literal, TypeVar, Union, cast, get_args, get_origin
+from typing import Any, Literal, TypeVar, Union, cast, get_args
 
 from fastapi._compat import (
     get_definitions,
@@ -15,7 +15,6 @@ from fastapi.openapi.utils import (
 from fastapi.routing import APIRoute
 from pydantic import BaseModel, Field, RootModel
 
-from cadwyn._asts import GenericAliasUnionArgs
 from cadwyn._utils import ZIP_STRICT_FALSE, Sentinel
 from cadwyn.route_generation import _get_routes
 from cadwyn.routing import _RootCadwynAPIRouter
@@ -138,17 +137,9 @@ def _get_affected_model_names(
 
 
 def _get_all_pydantic_models_from_generic(annotation: Any) -> list[type[BaseModel]]:
-    # https://docs.python.org/3/whatsnew/3.14.html#typing
-    if sys.version_info >= (3, 14):  # pragma: no cover
-        is_union = get_origin(annotation) is Union and not isinstance(annotation, type)
-    else:
-        is_union = isinstance(annotation, GenericAliasUnionArgs)
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        return [annotation]
 
-    if not is_union:
-        if isinstance(annotation, type) and issubclass(annotation, BaseModel):
-            return [annotation]
-        else:
-            return []
     sub_annotations = get_args(annotation)
     models = []
 


### PR DESCRIPTION
I feel like this is a workaround and not solving the root cause, and not sure it's the best approach but still wanted to submit because it's working.

---

Fixes the last remaining weird union issue with Python 3.14. I used Claude (Opus 4.6) to debug the issue and this was the explanation for the changes in this commit:

> The function doesn't handle nested generics like list[X | Y]. It checks if the annotation is a union or a BaseModel, but when it gets list[UserUpdateRequest | None]:

> is_union → False (it's a list, not a union)
> isinstance(annotation, type) and issubclass(annotation, BaseModel) → False (it's a generic alias)
> Returns [] — UserUpdateRequest is never discovered

> On 3.12 this worked because pydantic's model_fields apparently provided Optional[UserUpdateRequest] as the annotation (the inner type of the list), whereas on 3.14 it's providing the full list[UserUpdateRequest | None].
> The fix: Recurse into get_args() for any generic type, not just unions: