### PR TITLE
Add basic renovate config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,7 @@ repos:
     rev: 1.19.1 # replace with latest tag on GitHub
     hooks:
       - id: blacken-docs
+        language: python
         additional_dependencies:
           - black==22.12.0
         args:
@@ -45,3 +46,12 @@ repos:
     rev: 0.10.0
     hooks:
       - id: uv-lock
+
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.36.2
+    hooks:
+      - id: check-renovate
+        files: ^renovate.json5$
+        language: python
+        additional_dependencies:
+          - pyjson5==2.0.0

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    // https://docs.renovatebot.com/presets-config/#configrecommended
+    "config:recommended",
+  ],
+  "pre-commit": {
+    "enabled": true,
+  }
+}


### PR DESCRIPTION
"language" key in git hooks config is needed for https://docs.renovatebot.com/modules/manager/pre-commit/#additional-dependencies

---

Coming from https://github.com/zmievsa/cadwyn/pull/332#issuecomment-3899418199

After merging the PR, the Renovate app should be installed for the repo: https://docs.renovatebot.com/getting-started/installing-onboarding/#repository-installation

I have an [extensive config](https://github.com/ulgens/renovate-presets) I use for my own projects, which includes grouping for several ecosystems and hash pinning for GHA but I thought a lighter config is better for starters.