### PR TITLE
Add Python 3.14 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,8 @@ jobs:
             python-version: "3.12"
           - os: ubuntu-latest
             python-version: "3.13"
+          - os: ubuntu-latest
+            python-version: "3.14"
           - os: windows-latest
             python-version: "3.10"
           - os: macos-latest

--- a/.github/workflows/daily_tests.yaml
+++ b/.github/workflows/daily_tests.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v6

--- a/cadwyn/changelogs.py
+++ b/cadwyn/changelogs.py
@@ -2,7 +2,7 @@ import copy
 import sys
 from enum import auto
 from logging import getLogger
-from typing import Any, Literal, TypeVar, Union, cast, get_args, get_origin
+from typing import Any, Literal, TypeVar, Union, cast, get_args
 
 from fastapi._compat import (
     get_definitions,
@@ -138,13 +138,7 @@ def _get_affected_model_names(
 
 
 def _get_all_pydantic_models_from_generic(annotation: Any) -> list[type[BaseModel]]:
-    # https://docs.python.org/3/whatsnew/3.14.html#typing
-    if sys.version_info >= (3, 14):  # pragma: no cover
-        is_union = get_origin(annotation) is Union and not isinstance(annotation, type)
-    else:
-        is_union = isinstance(annotation, GenericAliasUnionArgs)
-
-    if not is_union:
+    if not isinstance(annotation, GenericAliasUnionArgs):
         if isinstance(annotation, type) and issubclass(annotation, BaseModel):
             return [annotation]
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ keywords = [
     "python311",
     "python312",
     "python313",
+    "python314",
 ]
 classifiers = [
     "Intended Audience :: Information Technology",
@@ -33,6 +34,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Internet",
     "Topic :: Software Development :: Libraries :: Application Frameworks",
     "Topic :: Software Development :: Libraries :: Python Modules",

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     # When updating Python versions, use search-and-replace
     # against the entire list of of versions
     # to ensure consistency throughout this file.
-    py{3.13, 3.12, 3.11, 3.10}
+    py{3.14, 3.13, 3.12, 3.11, 3.10}
     coverage_report
     docs
     pyright
@@ -18,7 +18,7 @@ extras =
 package = wheel
 wheel_build_env = build_wheel
 depends =
-    py{3.13, 3.12, 3.11, 3.10}: coverage_erase
+    py{3.14, 3.13, 3.12, 3.11, 3.10}: coverage_erase
 commands = coverage run -m pytest {posargs}
 
 
@@ -30,7 +30,7 @@ commands = coverage erase
 [testenv:coverage_report]
 skip_install = true
 depends =
-    py{3.13, 3.12, 3.11, 3.10}
+    py{3.14, 3.13, 3.12, 3.11, 3.10}
 commands_pre =
     # Ignore the exit code of `coverage combine`
     # (in case the reports are already combined).


### PR DESCRIPTION
In Python 3.14, typing.Union is no longer a subtype of typing._BaseGenericAlias, which broke changelog model detection for annotations like list[Union[Model, None]]. Fix by extending GenericAliasUnionArgs to include the new union type on 3.14 and using it uniformly instead of the version-gated get_origin() check.