### PR TITLE
respect response_model on routes. Fixes #365

### DIFF
--- a/cadwyn/route_generation.py
+++ b/cadwyn/route_generation.py
@@ -120,7 +120,7 @@ def copy_route(route: _RouteT) -> _RouteT:
     # These can hold TypeAdapters for recursive types (e.g. JsonValue) that cause
     # infinite recursion during deepcopy.
     memo: dict[int, Any] = {}
-    for attr in ("dependant", "_flat_dependant", "body_field"):
+    for attr in ("dependant", "_flat_dependant", "body_field", "response_model"):
         obj = getattr(route, attr, None)
         if obj is not None:
             memo[id(obj)] = obj

--- a/cadwyn/schema_generation.py
+++ b/cadwyn/schema_generation.py
@@ -609,7 +609,9 @@ class _AnnotationTransformer:
     def _remake_endpoint_dependencies(cls, route: fastapi.routing.APIRoute):
         # Unlike get_dependant, APIRoute is the public API of FastAPI and it's (almost) guaranteed to be stable.
 
-        route_copy = fastapi.routing.APIRoute(route.path, route.endpoint, dependencies=route.dependencies)
+        route_copy = fastapi.routing.APIRoute(
+            route.path, route.endpoint, dependencies=route.dependencies, response_model=route.response_model
+        )
         route.dependant = route_copy.dependant
         route.body_field = route_copy.body_field
         _add_request_and_response_params(route)

--- a/tests/test_response_model.py
+++ b/tests/test_response_model.py
@@ -1,0 +1,41 @@
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+
+from cadwyn.applications import Cadwyn
+from cadwyn.route_generation import VersionedAPIRouter
+from cadwyn.structure.versions import HeadVersion, Version, VersionBundle
+
+
+class Response(BaseModel):
+    foo: float
+
+
+router = VersionedAPIRouter()
+
+
+@router.get("/test", response_model=Response)
+def _test() -> Response | JSONResponse:
+    return Response(foo=11.1)
+
+
+def test__response_model_respected():
+    app = Cadwyn(
+        versions=VersionBundle(HeadVersion(), Version("2023-04-14")),
+    )
+
+    app.generate_and_include_versioned_routers(router)
+
+    with TestClient(app) as client:
+        resp = client.get("/docs")
+        assert resp.status_code == 200, resp.json()
+
+        resp = client.get("/docs?version=2023-04-14")
+        assert resp.status_code == 200, resp.json()
+
+        resp = client.get("/test")
+        assert resp.status_code == 404, resp.json()
+
+        resp = client.get("/test", headers={"X-API-VERSION": "2023-04-14"})
+        assert resp.status_code == 200, resp.json()
+        assert resp.json() == {"foo": 11.1}, resp.json()

--- a/tests/test_router_generation.py
+++ b/tests/test_router_generation.py
@@ -1440,3 +1440,34 @@ def test__copy_route__without_flat_dependant():
     copied = copy_route(route)
     assert copied.path == route.path
     assert not hasattr(copied, "_flat_dependant")
+
+
+def test__copy_route__preserves_response_model():
+    """Test that copy_route preserves the response_model without deep-copying it."""
+    route = APIRoute("/test", lambda: None, response_model=SchemaWithOneIntField)
+    copied = copy_route(route)
+    assert copied.path == route.path
+    assert copied.response_model is route.response_model
+
+
+def test__router_generation__remake_endpoint_dependencies_preserves_response_model(
+    router: VersionedAPIRouter,
+    create_versioned_app: CreateVersionedApp,
+):
+    """Test that _remake_endpoint_dependencies correctly passes response_model
+
+    when recreating the route, ensuring response_field stays consistent.
+    """
+
+    @router.get(
+        "/test",
+        response_model=SchemaWithOneIntField,
+    )
+    async def test():
+        raise NotImplementedError
+
+    app = create_versioned_app(version_change())
+    routes_2001 = cast("list[APIRoute]", app.router.versioned_routers["2001-01-01"].routes)
+    api_route = next(r for r in routes_2001 if r.path == "/test")
+    assert api_route.response_model is not None
+    assert api_route.response_field is not None

--- a/tests/test_router_generation.py
+++ b/tests/test_router_generation.py
@@ -1440,34 +1440,3 @@ def test__copy_route__without_flat_dependant():
     copied = copy_route(route)
     assert copied.path == route.path
     assert not hasattr(copied, "_flat_dependant")
-
-
-def test__copy_route__preserves_response_model():
-    """Test that copy_route preserves the response_model without deep-copying it."""
-    route = APIRoute("/test", lambda: None, response_model=SchemaWithOneIntField)
-    copied = copy_route(route)
-    assert copied.path == route.path
-    assert copied.response_model is route.response_model
-
-
-def test__router_generation__remake_endpoint_dependencies_preserves_response_model(
-    router: VersionedAPIRouter,
-    create_versioned_app: CreateVersionedApp,
-):
-    """Test that _remake_endpoint_dependencies correctly passes response_model
-
-    when recreating the route, ensuring response_field stays consistent.
-    """
-
-    @router.get(
-        "/test",
-        response_model=SchemaWithOneIntField,
-    )
-    async def test():
-        raise NotImplementedError
-
-    app = create_versioned_app(version_change())
-    routes_2001 = cast("list[APIRoute]", app.router.versioned_routers["2001-01-01"].routes)
-    api_route = next(r for r in routes_2001 if r.path == "/test")
-    assert api_route.response_model is not None
-    assert api_route.response_field is not None


### PR DESCRIPTION
if the return type annotation is not a concrete Pydantic type FastAPI will throw an error. So app routes can define `response_model`. However Cadwyn did not respect this.
See https://github.com/zmievsa/cadwyn/issues/365 for more information