### PR TITLE
Add support for fastapi's lazy routers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Please follow [the Keep a Changelog standard](https://keepachangelog.com/en/1.0.
 
 ## [Unreleased]
 
+## [7.1.0]
+
+### Added
+
+- Support FastAPI 0.137.1+ included-router trees, including routes added to included routers after inclusion, for Cadwyn's versioned and unversioned routing
+
 ## [7.0.0]
 
 - Breaking change if you relied on lifespan running multiple times: Fixed duplicated lifecycle callbacks in Cadwyn routers, see [this issue](https://github.com/zmievsa/cadwyn/issues/372) for more details

--- a/cadwyn/applications.py
+++ b/cadwyn/applications.py
@@ -52,9 +52,7 @@ CURR_DIR = Path(__file__).resolve()
 logger = getLogger(__name__)
 
 
-def _get_effective_include_in_schema(
-    route: BaseRoute, effective_route_context: _EffectiveRouteContext | None
-) -> bool:
+def _get_effective_include_in_schema(route: BaseRoute, effective_route_context: _EffectiveRouteContext | None) -> bool:
     if effective_route_context is not None:
         starlette_route = effective_route_context.starlette_route
         if starlette_route is not None:

--- a/cadwyn/applications.py
+++ b/cadwyn/applications.py
@@ -18,6 +18,7 @@ from fastapi.openapi.docs import (
 from fastapi.openapi.utils import get_openapi
 from fastapi.params import Depends
 from fastapi.responses import HTMLResponse
+from fastapi.routing import _EffectiveRouteContext, _IncludedRouter, _iter_routes_with_context
 from fastapi.templating import Jinja2Templates
 from fastapi.utils import generate_unique_id
 from starlette.middleware import Middleware
@@ -38,7 +39,7 @@ from cadwyn.middleware import (
     VersionPickingMiddleware,
     _generate_api_version_dependency,
 )
-from cadwyn.route_generation import generate_versioned_routers
+from cadwyn.route_generation import copy_route, generate_versioned_routers
 from cadwyn.routing import _RootCadwynAPIRouter
 from cadwyn.structure import VersionBundle
 
@@ -49,6 +50,24 @@ if TYPE_CHECKING:
 
 CURR_DIR = Path(__file__).resolve()
 logger = getLogger(__name__)
+
+
+def _get_effective_include_in_schema(
+    route: BaseRoute, effective_route_context: _EffectiveRouteContext | None
+) -> bool:
+    if effective_route_context is not None:
+        starlette_route = effective_route_context.starlette_route
+        if starlette_route is not None:
+            return bool(getattr(starlette_route, "include_in_schema", False))
+        return bool(effective_route_context.include_in_schema)
+    return bool(getattr(route, "include_in_schema", False))
+
+
+def _materialize_routes(routes: Sequence[BaseRoute]) -> list[BaseRoute]:
+    return [
+        copy_route(route, effective_route_context) if effective_route_context is not None else route
+        for route, effective_route_context in _iter_routes_with_context(routes)
+    ]
 
 
 @dataclasses.dataclass(**DATACLASS_SLOTS)
@@ -255,7 +274,13 @@ class Cadwyn(FastAPI):
         unversioned_router = APIRouter(**self._kwargs_to_router)
         self._add_utility_endpoints(unversioned_router)
         self._add_default_versioned_routers()
+        route_count_before_include = len(self.router.routes)
+        unversioned_route_count_before_include = len(self.router.unversioned_routes)
         self.include_router(unversioned_router)
+        utility_routes = _materialize_routes(self.router.routes[route_count_before_include:])
+        self.router.routes[route_count_before_include:] = utility_routes
+        self.router.unversioned_routes[unversioned_route_count_before_include:] = utility_routes
+        self.router._mark_routes_changed()
         self.add_middleware(
             versioning_middleware_class,
             api_version_parameter_name=api_version_parameter_name,
@@ -411,15 +436,19 @@ class Cadwyn(FastAPI):
         )
 
     def _there_are_public_unversioned_routes(self):
-        return any(isinstance(route, Route) and route.include_in_schema for route in self.router.unversioned_routes)
+        return any(
+            isinstance(route, Route) and _get_effective_include_in_schema(route, effective_route_context)
+            for route, effective_route_context in _iter_routes_with_context(self.router.unversioned_routes)
+        )
 
     def _filter_openapi_tags(self, routes: list) -> Union[list[dict[str, Any]], None]:
         if not self.openapi_tags:
             return self.openapi_tags
         used_tags: set[str | Enum] = set()
-        for route in routes:
-            if isinstance(route, routing.APIRoute) and route.include_in_schema:
-                used_tags.update(route.tags)
+        for route, effective_route_context in _iter_routes_with_context(routes):
+            route_data = cast("Any", effective_route_context or route)
+            if isinstance(route, routing.APIRoute) and route_data.include_in_schema:
+                used_tags.update(route_data.tags)
         return [tag for tag in self.openapi_tags if tag.get("name") in used_tags]
 
     async def swagger_dashboard(self, req: Request) -> Response:
@@ -505,8 +534,8 @@ class Cadwyn(FastAPI):
             )
             added_routes.append(versioned_router.routes[-1])
 
-        added_route_count = 0
         for router in (first_router, *other_routers):
+            route_count_before_include = len(versioned_router.routes)
             self.router.versioned_routers[version].include_router(
                 router,
                 dependencies=[
@@ -522,9 +551,15 @@ class Cadwyn(FastAPI):
                     )
                 ],
             )
-            added_route_count += len(router.routes)
+            newly_added_routes = versioned_router.routes[route_count_before_include:]
+            if not any(isinstance(route, _IncludedRouter) for route in router.routes):
+                # There is no nested FastAPI include tree to preserve, so Cadwyn can materialize the plain
+                # routes here and keep the root router's version bookkeeping stable.
+                newly_added_routes = _materialize_routes(newly_added_routes)
+                versioned_router.routes[route_count_before_include:] = newly_added_routes
+                versioned_router._mark_routes_changed()
+            added_routes.extend(newly_added_routes)
 
-        added_routes.extend(versioned_router.routes[-added_route_count:])
-        self.router.routes.extend(added_routes)
+        self.router.extend_routes(added_routes)
 
         return added_routes

--- a/cadwyn/route_generation.py
+++ b/cadwyn/route_generation.py
@@ -11,12 +11,9 @@ from typing import (
     cast,
 )
 
-import fastapi.params
 import fastapi.routing
-import fastapi.security.base
-import fastapi.utils
 from fastapi import APIRouter
-from fastapi.routing import APIRoute
+from fastapi.routing import APIRoute, _EffectiveRouteContext, _iter_routes_with_context
 from pydantic import BaseModel
 from starlette.routing import BaseRoute
 from typing_extensions import TypeVar, assert_never
@@ -104,11 +101,26 @@ class VersionedAPIRouter(fastapi.routing.APIRouter):
 
 def copy_router(router: _R) -> _R:
     router = copy(router)
-    router.routes = [copy_route(r) for r in router.routes]
+    router.routes = [
+        copy_route(route, effective_route_context)
+        for route, effective_route_context in _iter_routes_with_context(router.routes)
+    ]
+    router._mark_routes_changed()
     return router
 
 
-def copy_route(route: _RouteT) -> _RouteT:
+def copy_route(route: _RouteT, effective_route_context: _EffectiveRouteContext | None = None) -> _RouteT:
+    """Copy a route and materialize FastAPI's include-router context into the copy.
+
+    FastAPI 0.137+ keeps included routers as tree nodes. Its _EffectiveRouteContext is the merged
+    route state produced by that tree: prefix, dependencies, tags, responses, schema flags, etc.
+    Cadwyn mutates copied routes per API version, so it must copy the original route and apply that
+    effective state to the copy. The original router tree is left intact.
+    """
+    if effective_route_context is not None and not isinstance(route, APIRoute):
+        if effective_route_context.starlette_route is not None:
+            return cast("_RouteT", copy(effective_route_context.starlette_route))
+
     if not isinstance(route, APIRoute):
         return copy(route)
 
@@ -120,17 +132,44 @@ def copy_route(route: _RouteT) -> _RouteT:
     # These can hold TypeAdapters for recursive types (e.g. JsonValue) that cause
     # infinite recursion during deepcopy.
     memo: dict[int, Any] = {}
-    for attr in ("dependant", "_flat_dependant", "body_field", "response_model"):
+    for attr in ("dependant", "_flat_dependant", "body_field", "response_model", "dependency_overrides_provider"):
         obj = getattr(route, attr, None)
         if obj is not None:
             memo[id(obj)] = obj
     new_route = deepcopy(route, memo)
-    new_route.dependant = copy(route.dependant)
-    if getattr(route, "_flat_dependant", None) is not None:
-        new_route._flat_dependant = copy(route._flat_dependant)
-    new_route.body_field = route.body_field
-    new_route.dependencies = copy(route.dependencies)
+    if effective_route_context is not None:
+        _apply_effective_route_context_to_route(new_route, effective_route_context)
+        _refresh_route_app(new_route)
+    else:
+        new_route.dependant = copy(route.dependant)
+        if getattr(route, "_flat_dependant", None) is not None:
+            new_route._flat_dependant = copy(route._flat_dependant)
+        new_route.body_field = route.body_field
+        new_route.dependencies = copy(route.dependencies)
     return new_route
+
+
+def _apply_effective_route_context_to_route(route: APIRoute, effective_route_context: _EffectiveRouteContext) -> None:
+    for attr_name, attr_value in vars(effective_route_context).items():
+        if attr_name in {"original_route", "starlette_route"}:
+            continue
+        setattr(route, attr_name, _copy_effective_route_context_attr(attr_name, attr_value))
+
+
+def _copy_effective_route_context_attr(attr_name: str, attr_value: Any) -> Any:
+    if attr_name in {"dependant", "_flat_dependant"} and attr_value is not None:
+        return copy(attr_value)
+    if isinstance(attr_value, (dict, list, set)):
+        return copy(attr_value)
+    return attr_value
+
+
+def _refresh_route_app(route: APIRoute) -> None:
+    route.app = fastapi.routing.request_response(route.get_route_handler())
+
+
+def _route_methods(route: APIRoute) -> set[str]:
+    return route.methods or set()
 
 
 class _EndpointTransformer(Generic[_R, _WR]):
@@ -149,9 +188,12 @@ class _EndpointTransformer(Generic[_R, _WR]):
         self.api_version_parameter_name = api_version_parameter_name
         self.api_version_location: APIVersionLocation = api_version_location
         self.schema_generators = generate_versioned_models(versions)
+        self.head_router = copy_router(parent_router)
 
         self.routes_that_never_existed = [
-            route for route in parent_router.routes if isinstance(route, APIRoute) and _DELETED_ROUTE_TAG in route.tags
+            route
+            for route in self.head_router.routes
+            if isinstance(route, APIRoute) and _DELETED_ROUTE_TAG in route.tags
         ]
 
     def transform(self) -> GeneratedRouters[_R, _WR]:
@@ -165,7 +207,7 @@ class _EndpointTransformer(Generic[_R, _WR]):
             self.schema_generators[str(version.value)].annotation_transformer.migrate_router_to_version(router)
             self.schema_generators[str(version.value)].annotation_transformer.migrate_router_to_version(webhook_router)
 
-            self._attach_routes_to_data_converters(router, self.parent_router, version)
+            self._attach_routes_to_data_converters(router, self.head_router, version)
 
             routers[version.value] = router
             webhook_routers[version.value] = webhook_router
@@ -183,7 +225,7 @@ class _EndpointTransformer(Generic[_R, _WR]):
                 f"{self.routes_that_never_existed}",
             )
 
-        for route_index, head_route in enumerate(self.parent_router.routes):
+        for route_index, head_route in enumerate(self.head_router.routes):
             if not isinstance(head_route, APIRoute):
                 continue
             _add_request_and_response_params(head_route)
@@ -326,7 +368,7 @@ class _EndpointTransformer(Generic[_R, _WR]):
                     annotation = route.body_field.field_info.annotation
                     if annotation is not None and lenient_issubclass(annotation, BaseModel):
                         request_bodies.add(annotation)
-                for method in route.methods:
+                for method in _route_methods(route):
                     path_to_route_methods_mapping[route.path][method].add(index)
 
         head_response_models = {model.__cadwyn_original_model__ for model in response_models}
@@ -363,7 +405,7 @@ class _EndpointTransformer(Generic[_R, _WR]):
                     if deleted_routes:
                         method_union = set()
                         for deleted_route in deleted_routes:
-                            method_union |= deleted_route.methods
+                            method_union |= _route_methods(deleted_route)
                         raise RouterGenerationError(
                             f'Endpoint "{list(method_union)} {instruction.endpoint_path}" you tried to delete in '
                             f'"{version_change.__name__}" was already deleted in a newer version. If you really have '
@@ -372,7 +414,7 @@ class _EndpointTransformer(Generic[_R, _WR]):
                             f"{[r.endpoint.__name__ for r in deleted_routes]}",
                         )
                     for original_route in original_routes:
-                        methods_to_which_we_applied_changes |= original_route.methods
+                        methods_to_which_we_applied_changes |= _route_methods(original_route)
                         original_route.tags.append(_DELETED_ROUTE_TAG)
                     err = (
                         'Endpoint "{endpoint_methods} {endpoint_path}" you tried to delete in'
@@ -382,7 +424,7 @@ class _EndpointTransformer(Generic[_R, _WR]):
                     if original_routes:
                         method_union = set()
                         for original_route in original_routes:
-                            method_union |= original_route.methods
+                            method_union |= _route_methods(original_route)
                         raise RouterGenerationError(
                             f'Endpoint "{list(method_union)} {instruction.endpoint_path}" you tried to restore in'
                             f' "{version_change.__name__}" already existed in a newer version. If you really have two '
@@ -408,13 +450,13 @@ class _EndpointTransformer(Generic[_R, _WR]):
                             f"endpoints that can be restored: {[r.endpoint.__name__ for r in e.routes]}",
                         ) from e
                     for deleted_route in deleted_routes:
-                        methods_to_which_we_applied_changes |= deleted_route.methods
+                        methods_to_which_we_applied_changes |= _route_methods(deleted_route)
                         deleted_route.tags.remove(_DELETED_ROUTE_TAG)
 
                         routes_that_never_existed = _get_routes(
                             self.routes_that_never_existed,
                             deleted_route.path,
-                            deleted_route.methods,
+                            _route_methods(deleted_route),
                             deleted_route.endpoint.__name__,
                             is_deleted=True,
                         )
@@ -425,7 +467,8 @@ class _EndpointTransformer(Generic[_R, _WR]):
                             # to remove it because I like its clarity very much
                             routes = routes_that_never_existed
                             raise RouterGenerationError(
-                                f'Endpoint "{list(deleted_route.methods)} {deleted_route.path}" you tried to restore '
+                                f'Endpoint "{list(_route_methods(deleted_route))} {deleted_route.path}" '
+                                "you tried to restore "
                                 f'in "{version_change.__name__}" has {len(routes_that_never_existed)} applicable '
                                 f"routes with the same function name and path that could be restored. This can cause "
                                 f"problems during version generation. Specifically, Cadwyn won't be able to warn "
@@ -439,7 +482,7 @@ class _EndpointTransformer(Generic[_R, _WR]):
                     )
                 elif isinstance(instruction, EndpointHadInstruction):
                     for original_route in original_routes:
-                        methods_to_which_we_applied_changes |= original_route.methods
+                        methods_to_which_we_applied_changes |= _route_methods(original_route)
                         _apply_endpoint_had_instruction(
                             version_change.__name__,
                             instruction,
@@ -468,7 +511,7 @@ def _validate_no_repetitions_in_routes(routes: list[fastapi.routing.APIRoute]):
     route_map = {}
 
     for route in routes:
-        route_info = _EndpointInfo(route.path, frozenset(route.methods))
+        route_info = _EndpointInfo(route.path, frozenset(_route_methods(route)))
         if route_info in route_map:
             raise RouteAlreadyExistsError(route, route_map[route_info])
         route_map[route_info] = route
@@ -485,7 +528,8 @@ def _add_data_migrations_to_route(
     if not (route.dependant.request_param_name and route.dependant.response_param_name):  # pragma: no cover
         raise CadwynError(
             f"{route.dependant.request_param_name=}, {route.dependant.response_param_name=} "
-            f"for route {list(route.methods)} {route.path} which should not be possible. Please, contact my author.",
+            f"for route {list(_route_methods(route))} {route.path} which should not be possible. "
+            "Please, contact my author.",
         )
 
     route.endpoint = versions._versioned(
@@ -514,7 +558,7 @@ def _apply_endpoint_had_instruction(
             if getattr(original_route, attr_name) == attr:
                 raise RouterGenerationError(
                     f'Expected attribute "{attr_name}" of endpoint'
-                    f' "{list(original_route.methods)} {original_route.path}"'
+                    f' "{list(_route_methods(original_route))} {original_route.path}"'
                     f' to be different in "{version_change_name}", but it was the same.'
                     " It means that your version change has no effect on the attribute"
                     " and can be removed.",
@@ -526,7 +570,7 @@ def _apply_endpoint_had_instruction(
                     new_path_params.discard(api_version_parameter_name)
                 if new_path_params != original_path_params:
                     raise RouterPathParamsModifiedError(
-                        f'When altering the path of "{list(original_route.methods)} {original_route.path}" '
+                        f'When altering the path of "{list(_route_methods(original_route))} {original_route.path}" '
                         f'in "{version_change_name}", you have tried to change its path params '
                         f'from "{list(original_path_params)}" to "{list(new_path_params)}". It is not allowed to '
                         "change the path params of a route because the endpoint was created to handle the old path "
@@ -552,7 +596,7 @@ def _get_routes(
         if (
             isinstance(route, fastapi.routing.APIRoute)
             and route.path.rstrip("/") == endpoint_path
-            and set(route.methods).issubset(endpoint_methods)
+            and _route_methods(route).issubset(endpoint_methods)
             and (endpoint_func_name is None or route.endpoint.__name__ == endpoint_func_name)
             and (_DELETED_ROUTE_TAG in route.tags) == is_deleted
         )
@@ -563,7 +607,7 @@ def _get_route_from_func(
     routes: Sequence[BaseRoute],
     endpoint: Endpoint,
 ) -> Union[fastapi.routing.APIRoute, None]:
-    for route in routes:
+    for route, _effective_route_context in _iter_routes_with_context(routes):
         if isinstance(route, fastapi.routing.APIRoute) and (route.endpoint == endpoint):
             return route
     return None

--- a/cadwyn/route_generation.py
+++ b/cadwyn/route_generation.py
@@ -117,9 +117,12 @@ def copy_route(route: _RouteT, effective_route_context: _EffectiveRouteContext |
     Cadwyn mutates copied routes per API version, so it must copy the original route and apply that
     effective state to the copy. The original router tree is left intact.
     """
-    if effective_route_context is not None and not isinstance(route, APIRoute):
-        if effective_route_context.starlette_route is not None:
-            return cast("_RouteT", copy(effective_route_context.starlette_route))
+    if (
+        effective_route_context is not None
+        and not isinstance(route, APIRoute)
+        and effective_route_context.starlette_route is not None
+    ):
+        return cast("_RouteT", copy(effective_route_context.starlette_route))
 
     if not isinstance(route, APIRoute):
         return copy(route)

--- a/cadwyn/routing.py
+++ b/cadwyn/routing.py
@@ -106,7 +106,7 @@ class _RootCadwynAPIRouter(APIRouter):
         routes_before = len(self.routes)
         unversioned_routes_before = len(self.unversioned_routes)
         super().include_router(*args, **kwargs)
-        if len(self.unversioned_routes) == unversioned_routes_before:
+        if len(self.unversioned_routes) == unversioned_routes_before:  # pragma: no branch
             self.unversioned_routes.extend(self.routes[routes_before:])
 
     @same_definition_as_in(APIRouter.add_route)

--- a/cadwyn/routing.py
+++ b/cadwyn/routing.py
@@ -101,6 +101,14 @@ class _RootCadwynAPIRouter(APIRouter):
         super().add_api_route(*args, **kwargs)
         self.unversioned_routes.append(self.routes[-1])
 
+    @same_definition_as_in(APIRouter.include_router)
+    def include_router(self, *args: Any, **kwargs: Any):
+        routes_before = len(self.routes)
+        unversioned_routes_before = len(self.unversioned_routes)
+        super().include_router(*args, **kwargs)
+        if len(self.unversioned_routes) == unversioned_routes_before:
+            self.unversioned_routes.extend(self.routes[routes_before:])
+
     @same_definition_as_in(APIRouter.add_route)
     def add_route(self, *args: Any, **kwargs: Any):
         super().add_route(*args, **kwargs)
@@ -162,3 +170,7 @@ class _RootCadwynAPIRouter(APIRouter):
                     return None
 
         return await self.default(scope, receive, send)
+
+    def extend_routes(self, routes: Sequence[BaseRoute]) -> None:
+        self.routes.extend(routes)
+        self._mark_routes_changed()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cadwyn"
-version = "7.0.0"
+version = "7.1.0"
 description = "Production-ready community-driven modern Stripe-like API versioning in FastAPI"
 authors = [{ name = "Stanislav Zmiev", email = "zmievsa@gmail.com" }]
 license = "MIT"
@@ -52,7 +52,7 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP",
 ]
 dependencies = [
-    "fastapi >=0.128.6",
+    "fastapi >=0.137.1",
     "starlette >=0.30.0",
     "pydantic >=2.11.0",
     "jinja2 >=3.1.2",
@@ -63,7 +63,7 @@ dependencies = [
 
 
 [project.optional-dependencies]
-standard = ["fastapi[standard]>=0.119.0", "typer>=0.7.0"]
+standard = ["fastapi[standard]>=0.137.1", "typer>=0.7.0"]
 
 
 [dependency-groups]

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -25,6 +25,7 @@ from tests._resources.versioned_app.app import (
 if TYPE_CHECKING:
     from fastapi.routing import APIRoute
 
+
 def test__header_routing__invalid_version_format__error():
     main_app = Cadwyn(versions=VersionBundle(Version("2022-11-16")))
     with pytest.warns(DeprecationWarning):

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -3,7 +3,7 @@ from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Annotated, cast
 
 import pytest
-from fastapi import APIRouter, BackgroundTasks, Depends, FastAPI
+from fastapi import APIRouter, BackgroundTasks, Depends, FastAPI, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.testclient import TestClient
 from pydantic import BaseModel
@@ -24,7 +24,6 @@ from tests._resources.versioned_app.app import (
 
 if TYPE_CHECKING:
     from fastapi.routing import APIRoute
-
 
 def test__header_routing__invalid_version_format__error():
     main_app = Cadwyn(versions=VersionBundle(Version("2022-11-16")))
@@ -158,6 +157,186 @@ def test__cadwyn__with_dependency_overrides__overrides_should_be_applied():
         assert client.post("/hello").json() == "new"
         assert client.post("/darkness", headers={"x-api-version": "2022-11-16"}).json() == "new"
         assert client.post("/my_old_friend", headers={"x-api-version": "2022-11-16"}).json() == "new"
+
+
+def test__unversioned_include_router__route_added_after_inclusion_is_available():
+    app = Cadwyn(versions=VersionBundle(Version("2022-11-16")))
+    parent_router = APIRouter(prefix="/api")
+    child_router = APIRouter()
+
+    def mark_parent_router_dependency(response: Response):
+        response.headers["x-parent-router-dependency"] = "ran"
+
+    parent_router.include_router(
+        child_router,
+        prefix="/health",
+        dependencies=[Depends(mark_parent_router_dependency)],
+    )
+    app.include_router(parent_router)
+
+    @child_router.get("")
+    async def healthcheck():
+        return {"ok": True}
+
+    with TestClient(app) as client:
+        response = client.get("/api/health")
+
+    assert response.status_code == 200, response.json()
+    assert response.json() == {"ok": True}
+    assert response.headers["x-parent-router-dependency"] == "ran"
+
+
+def test__unversioned_include_router__route_added_after_first_request_is_available():
+    app = Cadwyn(versions=VersionBundle(Version("2022-11-16")))
+    parent_router = APIRouter(prefix="/api")
+    child_router = APIRouter()
+    parent_router.include_router(child_router, prefix="/late")
+    app.include_router(parent_router)
+
+    with TestClient(app) as client:
+        response = client.get("/api/late/route")
+        assert response.status_code == 404, response.json()
+
+        @child_router.get("/route", name="late_route")
+        async def late_route():
+            return {"late": True}
+
+        assert app.url_path_for("late_route") == "/api/late/route"
+
+        response = client.get("/api/late/route")
+
+    assert response.status_code == 200, response.json()
+    assert response.json() == {"late": True}
+
+
+def test__unversioned_include_router__hidden_late_route_does_not_create_public_openapi_schema():
+    app = Cadwyn(changelog_url=None, versions=VersionBundle(Version("2022-11-16")))
+    parent_router = APIRouter()
+    child_router = APIRouter()
+    parent_router.include_router(child_router, prefix="/internal", include_in_schema=False)
+    app.include_router(parent_router)
+
+    @child_router.get("/health")
+    async def healthcheck():
+        return {"ok": True}
+
+    with TestClient(app) as client:
+        route_response = client.get("/internal/health")
+        schema_response = client.get("/openapi.json?version=unversioned")
+        docs_response = client.get("/docs")
+
+    assert route_response.status_code == 200, route_response.json()
+    assert route_response.json() == {"ok": True}
+    assert schema_response.status_code == 404, schema_response.json()
+    assert "version=unversioned" not in docs_response.text
+
+
+def test__unversioned_include_router__hidden_plain_route_does_not_create_public_openapi_schema():
+    app = Cadwyn(changelog_url=None, versions=VersionBundle(Version("2022-11-16")))
+    router = APIRouter()
+
+    async def hidden_route(_request):
+        return Response("hidden")
+
+    router.add_route("/internal/health", hidden_route, methods=["GET"], include_in_schema=False)
+    app.include_router(router)
+
+    with TestClient(app) as client:
+        route_response = client.get("/internal/health")
+        schema_response = client.get("/openapi.json?version=unversioned")
+        docs_response = client.get("/docs")
+
+    assert route_response.status_code == 200, route_response.text
+    assert route_response.text == "hidden"
+    assert schema_response.status_code == 404, schema_response.json()
+    assert "version=unversioned" not in docs_response.text
+
+
+def test__unversioned_include_router__included_tags_are_used_for_openapi_tag_filtering():
+    app = Cadwyn(
+        versions=VersionBundle(Version("2022-11-16")),
+        openapi_tags=[
+            {"name": "public", "description": "Public operations"},
+            {"name": "private", "description": "Private operations"},
+        ],
+    )
+    parent_router = APIRouter(tags=["private"])
+    child_router = APIRouter()
+    parent_router.include_router(child_router, prefix="/settings", tags=["public"])
+    app.include_router(parent_router)
+
+    @child_router.get("")
+    async def get_settings():
+        return {"settings": True}
+
+    with TestClient(app) as client:
+        route_response = client.get("/settings")
+        response = client.get("/openapi.json?version=unversioned")
+
+    assert route_response.status_code == 200, route_response.json()
+    assert route_response.json() == {"settings": True}
+    assert response.status_code == 200, response.json()
+    tag_names = {tag["name"] for tag in response.json()["tags"]}
+    assert tag_names == {"public", "private"}
+
+
+def test__versioned_include_router__late_route_uses_dependency_overrides():
+    app = Cadwyn(versions=VersionBundle(HeadVersion(), Version("2022-11-16")))
+    parent_router = VersionedAPIRouter(prefix="/api")
+    child_router = VersionedAPIRouter()
+
+    async def old_dependency():
+        raise NotImplementedError
+
+    async def new_dependency():
+        return "new"
+
+    parent_router.include_router(child_router, prefix="/deps")
+    app.generate_and_include_versioned_routers(parent_router)
+
+    @child_router.get("")
+    async def read_dependency_value(dependency: Annotated[str, Depends(old_dependency)]):
+        return dependency
+
+    app.dependency_overrides[old_dependency] = new_dependency
+
+    with TestClient(app) as client:
+        response = client.get("/api/deps", headers={"x-api-version": "2022-11-16"})
+
+    assert response.status_code == 200, response.json()
+    assert response.json() == "new"
+
+
+def test__default_version__unversioned_included_route_added_late_still_has_priority():
+    app = Cadwyn(
+        versions=VersionBundle(HeadVersion(), Version("2022-11-16")),
+        api_version_default_value="2022-11-16",
+    )
+    parent_router = APIRouter(prefix="/api")
+    child_router = APIRouter()
+    parent_router.include_router(child_router, prefix="/items")
+    app.include_router(parent_router)
+
+    versioned_router = VersionedAPIRouter(prefix="/api")
+
+    @versioned_router.get("/items")
+    async def versioned_items():
+        return {"source": "versioned"}
+
+    app.generate_and_include_versioned_routers(versioned_router)
+
+    @child_router.get("")
+    async def unversioned_items():
+        return {"source": "unversioned"}
+
+    with TestClient(app) as client:
+        default_response = client.get("/api/items")
+        versioned_response = client.get("/api/items", headers={"x-api-version": "2022-11-16"})
+
+    assert default_response.status_code == 200, default_response.json()
+    assert default_response.json() == {"source": "unversioned"}
+    assert versioned_response.status_code == 200, versioned_response.json()
+    assert versioned_response.json() == {"source": "versioned"}
 
 
 def test__header_routing_fastapi_add_header_versioned_routers__apirouter_is_empty__version_should_not_have_any_routes():

--- a/tests/test_router_generation.py
+++ b/tests/test_router_generation.py
@@ -44,6 +44,8 @@ from tests.conftest import (
 
 Default = object()
 Endpoint: TypeAlias = Callable[..., Awaitable[Any]]
+
+
 class StrEnum(str, Enum):
     a = auto()
 

--- a/tests/test_router_generation.py
+++ b/tests/test_router_generation.py
@@ -8,16 +8,18 @@ from uuid import UUID
 
 import pytest
 import svcs
-from fastapi import APIRouter, Body, Depends, UploadFile
-from fastapi.routing import APIRoute
+from fastapi import APIRouter, Body, Depends, Response, UploadFile
+from fastapi.routing import APIRoute, _EffectiveRouteContext
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from fastapi.security.http import HTTPBasic
+from fastapi.staticfiles import StaticFiles
 from fastapi.testclient import TestClient
 from inline_snapshot import snapshot
 from pydantic import BaseModel, Field, JsonValue
 from pydantic_settings import BaseSettings
 from pytest_fixture_classes import fixture_class
-from starlette.responses import FileResponse, JSONResponse
+from starlette.responses import FileResponse, JSONResponse, PlainTextResponse
+from starlette.routing import Route
 from typing_extensions import Any, NewType, TypeAlias, TypeAliasType, get_args
 
 from cadwyn import VersionBundle, VersionedAPIRouter
@@ -29,7 +31,7 @@ from cadwyn.schema_generation import generate_versioned_models
 from cadwyn.structure import Version, convert_request_to_next_version_for, endpoint, schema
 from cadwyn.structure.data import RequestInfo, ResponseInfo, convert_response_to_previous_version_for
 from cadwyn.structure.enums import enum
-from cadwyn.structure.versions import VersionChange
+from cadwyn.structure.versions import HeadVersion, VersionChange
 from tests._data.unversioned_schema_dir import UnversionedSchema2
 from tests._data.unversioned_schema_dir.unversioned_schemas import UnversionedSchema1
 from tests._data.unversioned_schemas import UnversionedSchema3
@@ -42,8 +44,6 @@ from tests.conftest import (
 
 Default = object()
 Endpoint: TypeAlias = Callable[..., Awaitable[Any]]
-
-
 class StrEnum(str, Enum):
     a = auto()
 
@@ -140,6 +140,42 @@ def test__endpoint_existed(
 
     assert len(routes_2001) == 2
     assert endpoints_equal(routes_2001[1].endpoint, test_endpoint_post)
+
+
+def test__endpoint_existed__route_from_included_router(
+    create_versioned_api_routes: CreateVersionedAPIRoutes,
+):
+    router = VersionedAPIRouter()
+    child_router = VersionedAPIRouter()
+
+    @child_router.get("/test")
+    async def test_endpoint():
+        raise NotImplementedError
+
+    router.include_router(child_router)
+    router.only_exists_in_older_versions(test_endpoint)
+
+    routes_2000, routes_2001 = create_versioned_api_routes(
+        version_change(endpoint("/test", ["GET"]).existed),
+        router=router,
+    )
+
+    assert len(routes_2000) == 2
+    assert endpoints_equal(routes_2000[1].endpoint, test_endpoint)
+    assert len(routes_2001) == 1
+
+
+def test__copy_route__copies_plain_route_when_effective_context_has_no_starlette_route():
+    def plain_route(_request):
+        return PlainTextResponse("plain")
+
+    route = Route("/plain", plain_route, methods=["GET"])
+    copied_route = copy_route(route, _EffectiveRouteContext(original_route=route))
+
+    assert copied_route is not route
+    assert copied_route.path == "/plain"
+    assert copied_route.endpoint is plain_route
+    assert copied_route.endpoint(None).body == b"plain"
 
 
 def test__endpoint_existed__endpoint_removed_in_latest_but_never_restored__should_raise_error(
@@ -279,6 +315,198 @@ def test__endpoint_had__path_rename_with_api_version_in_prefix__should_not_raise
     client_v2 = TestClient(cadwyn_app)
     assert client_v2.get("/v2/new-name").json() == 83
     assert client_v2.get("/v1/old-name").json() == 83
+
+
+def test__versioned_router_generation__uses_routes_added_to_included_router_after_inclusion():
+    api_router = VersionedAPIRouter(prefix="/api/v1")
+    widgets_router = VersionedAPIRouter()
+
+    def mark_included_router_dependency(response: Response):
+        response.headers["x-included-router-dependency"] = "ran"
+
+    api_router.include_router(
+        widgets_router,
+        prefix="/widgets",
+        dependencies=[Depends(mark_included_router_dependency)],
+    )
+
+    class V2003(VersionChange):
+        description = ""
+        instructions_to_migrate_to_previous_version = [
+            endpoint("/api/v1/widgets/{widget_id}/details", ["GET"]).had(path="/api/v1/widgets/{widget_id}"),
+        ]
+
+    class V2002(VersionChange):
+        description = ""
+        instructions_to_migrate_to_previous_version = [
+            endpoint("/api/v1/widgets/{widget_id}", ["GET"]).had(path="/api/v1/items/{widget_id}"),
+        ]
+
+    app = Cadwyn(
+        versions=VersionBundle(
+            HeadVersion(),
+            Version("2003-01-01", V2003),
+            Version("2002-01-01", V2002),
+            Version("2001-01-01"),
+        )
+    )
+    app.generate_and_include_versioned_routers(api_router)
+
+    @widgets_router.get("/{widget_id}/details")
+    async def get_widget(widget_id: int):
+        return {"widget_id": widget_id}
+
+    with TestClient(app) as client:
+        response_2003 = client.get("/api/v1/widgets/7/details", headers={"x-api-version": "2003-01-01"})
+        response_2002 = client.get("/api/v1/widgets/7", headers={"x-api-version": "2002-01-01"})
+        response_2001 = client.get("/api/v1/items/7", headers={"x-api-version": "2001-01-01"})
+
+    for response in (response_2003, response_2002, response_2001):
+        assert response.status_code == 200, response.json()
+        assert response.json() == {"widget_id": 7}
+        assert response.headers["x-included-router-dependency"] == "ran"
+
+
+def test__versioned_router_generation__preserves_included_route_openapi_metadata():
+    class Widget(BaseModel):
+        name: str
+
+    api_router = VersionedAPIRouter(prefix="/api/v1", tags=["api"], responses={400: {"description": "Bad API"}})
+    widgets_router = VersionedAPIRouter(tags=["widgets"])
+
+    api_router.include_router(
+        widgets_router,
+        prefix="/widgets",
+        tags=["included"],
+        responses={401: {"description": "Unauthorized"}},
+        deprecated=True,
+    )
+
+    app = Cadwyn(
+        versions=VersionBundle(
+            HeadVersion(),
+            Version("2003-01-01"),
+            Version("2002-01-01"),
+            Version("2001-01-01"),
+        )
+    )
+    app.generate_and_include_versioned_routers(api_router)
+
+    @widgets_router.post(
+        "/{widget_id}",
+        response_model=Widget,
+        status_code=201,
+        operation_id="createWidget",
+        tags=["handler"],
+        responses={404: {"description": "Missing widget"}},
+        openapi_extra={"x-widget-operation": "create"},
+    )
+    async def create_widget(widget_id: int, body: Widget):
+        return body
+
+    with TestClient(app) as client:
+        route_response = client.post(
+            "/api/v1/widgets/7",
+            headers={"x-api-version": "2003-01-01"},
+            json={"name": "hammer"},
+        )
+        schema_response = client.get("/openapi.json?version=2003-01-01")
+
+    assert route_response.status_code == 201, route_response.json()
+    assert route_response.json() == {"name": "hammer"}
+    assert schema_response.status_code == 200, schema_response.json()
+    operation = schema_response.json()["paths"]["/api/v1/widgets/{widget_id}"]["post"]
+    assert operation["deprecated"] is True
+    assert operation["operationId"] == "createWidget"
+    assert operation["x-widget-operation"] == "create"
+    assert operation["tags"] == ["api", "included", "widgets", "handler"]
+    assert operation["responses"]["201"]["description"] == "Successful Response"
+    assert operation["responses"]["400"]["description"] == "Bad API"
+    assert operation["responses"]["401"]["description"] == "Unauthorized"
+    assert operation["responses"]["404"]["description"] == "Missing widget"
+
+
+def test__versioned_router_generation__hidden_included_route_still_routes_but_is_removed_from_openapi():
+    api_router = VersionedAPIRouter(prefix="/api")
+    internal_router = VersionedAPIRouter()
+    api_router.include_router(internal_router, prefix="/internal", include_in_schema=False)
+
+    app = Cadwyn(versions=VersionBundle(HeadVersion(), Version("2022-11-16")))
+    app.generate_and_include_versioned_routers(api_router)
+
+    @internal_router.get("/health")
+    async def healthcheck():
+        return {"ok": True}
+
+    with TestClient(app) as client:
+        route_response = client.get("/api/internal/health", headers={"x-api-version": "2022-11-16"})
+        schema_response = client.get("/openapi.json?version=2022-11-16")
+
+    assert route_response.status_code == 200, route_response.json()
+    assert route_response.json() == {"ok": True}
+    assert "/api/internal/health" not in schema_response.json()["paths"]
+
+
+def test__versioned_router_generation__materializes_plain_routes_and_mounts_added_after_inclusion(tmp_path):
+    static_dir = tmp_path / "static"
+    static_dir.mkdir()
+    (static_dir / "hello.txt").write_text("Hello World")
+
+    api_router = VersionedAPIRouter(prefix="/api")
+    tools_router = VersionedAPIRouter()
+    api_router.include_router(tools_router, prefix="/tools")
+
+    app = Cadwyn(versions=VersionBundle(HeadVersion(), Version("2022-11-16")))
+    app.generate_and_include_versioned_routers(api_router)
+
+    async def plain_route(_request):
+        return PlainTextResponse("plain")
+
+    tools_router.add_route("/plain", plain_route, methods=["GET"])
+    tools_router.mount("/static", StaticFiles(directory=static_dir), name="static")
+
+    with TestClient(app) as client:
+        plain_response = client.get("/api/tools/plain", headers={"x-api-version": "2022-11-16"})
+        static_response = client.get("/api/tools/static/hello.txt", headers={"x-api-version": "2022-11-16"})
+
+    assert plain_response.status_code == 200, plain_response.text
+    assert plain_response.text == "plain"
+    assert static_response.status_code == 200, static_response.text
+    assert static_response.text == "Hello World"
+
+
+def test__add_header_versioned_routers__uses_routes_added_to_included_router_after_cadwyn_inclusion():
+    app = Cadwyn(versions=VersionBundle(Version("2022-11-16")))
+    api_router = APIRouter(prefix="/api")
+    items_router = APIRouter()
+
+    def mark_included_router_dependency(response: Response):
+        response.headers["x-included-router-dependency"] = "ran"
+
+    api_router.include_router(
+        items_router,
+        prefix="/items",
+        dependencies=[Depends(mark_included_router_dependency)],
+    )
+
+    with pytest.warns(DeprecationWarning, match="Use generate_and_include_versioned_routers"):
+        app.add_header_versioned_routers(  # pyright: ignore[reportDeprecated]
+            api_router,
+            header_value="2022-11-16",
+        )
+
+    @items_router.get("/{item_id}")
+    async def get_item(item_id: int):
+        return {"item_id": item_id}
+
+    with TestClient(app) as client:
+        response = client.get("/api/items/11", headers={"x-api-version": "2022-11-16"})
+        schema_response = client.get("/openapi.json?version=2022-11-16")
+
+    assert response.status_code == 200, response.json()
+    assert response.json() == {"item_id": 11}
+    assert response.headers["x-included-router-dependency"] == "ran"
+    assert "/api/items/{item_id}" in schema_response.json()["paths"]
 
 
 def test__endpoint_had__another_path_with_the_other_migration_at_the_same_time__should_require_old_name(

--- a/uv.lock
+++ b/uv.lock
@@ -107,7 +107,7 @@ wheels = [
 
 [[package]]
 name = "cadwyn"
-version = "7.0.0"
+version = "7.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "backports-strenum", marker = "python_full_version < '3.11'" },
@@ -152,8 +152,8 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "backports-strenum", marker = "python_full_version < '3.11'", specifier = ">=1.3.1,<2" },
-    { name = "fastapi", specifier = ">=0.128.6" },
-    { name = "fastapi", extras = ["standard"], marker = "extra == 'standard'", specifier = ">=0.119.0" },
+    { name = "fastapi", specifier = ">=0.137.1" },
+    { name = "fastapi", extras = ["standard"], marker = "extra == 'standard'", specifier = ">=0.137.1" },
     { name = "jinja2", specifier = ">=3.1.2" },
     { name = "pydantic", specifier = ">=2.11.0" },
     { name = "starlette", specifier = ">=0.30.0" },
@@ -525,7 +525,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.136.3"
+version = "0.137.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -534,9 +534,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab", size = 396410, upload-time = "2026-05-23T18:53:15.192Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/b1/e5b92c59d2c37817e77c1a8c2fc1f79cdcc04c68253e5406b43e3204cba7/fastapi-0.137.1.tar.gz", hash = "sha256:822360704230d9533d8d9475399613525968aa2f0b5bd2a3ccc9f18c88fd541c", size = 408293, upload-time = "2026-06-15T11:28:20.79Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620", size = 117481, upload-time = "2026-05-23T18:53:16.924Z" },
+    { url = "https://files.pythonhosted.org/packages/da/35/380b9a5922f4340e51c309cde09e5bd32e62f02302971bee30dc15aa0624/fastapi-0.137.1-py3-none-any.whl", hash = "sha256:64f6983c59e45c4b9fdc44e57cb8035c2451ee91ea8e8ec042aca37de7cf6b69", size = 121877, upload-time = "2026-06-15T11:28:19.523Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Support FastAPI 0.137.1+ included-router trees, including routes added after inclusion, for both versioned and unversioned Cadwyn routing