### PR TITLE
fix: return matched API version after waterfalling

### DIFF
--- a/cadwyn/middleware.py
+++ b/cadwyn/middleware.py
@@ -125,6 +125,6 @@ class VersionPickingMiddleware(BaseHTTPMiddleware):
         if api_version is not None:
             # We return it because we will be returning the **matched** version, not the requested one.
             # In date-based versioning with waterfalling, it makes sense.
-            response.headers[self.api_version_parameter_name] = api_version
+            response.headers[self.api_version_parameter_name] = request.scope.get("cadwyn.api_version", api_version)
 
         return response

--- a/cadwyn/routing.py
+++ b/cadwyn/routing.py
@@ -82,6 +82,7 @@ class _RootCadwynAPIRouter(APIRouter):
             routes = self.versioned_routers[version].routes
         else:
             routes = await self._get_routes_from_closest_suitable_version(version)
+        scope["cadwyn.api_version"] = self.api_version_var.get(None)
         if default_version_that_was_picked:
             # We add unversioned routes to versioned routes because otherwise unversioned routes
             # will be completely unavailable when a default version is passed. So routes such as

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -40,6 +40,22 @@ def test__header_routing__invalid_version_format__error():
             )
 
 
+def test__header_routing__waterfalling_returns_matched_version():
+    app = Cadwyn(versions=VersionBundle(Version("2023-04-14"), Version("2022-11-16")))
+    router = VersionedAPIRouter()
+
+    @router.get("/foo")
+    def foo():
+        return "foo"
+
+    app.generate_and_include_versioned_routers(router)
+
+    response = TestClient(app).get("/foo", headers={"x-api-version": "2024-01-01"})
+
+    assert response.status_code == 200
+    assert response.headers["x-api-version"] == "2023-04-14"
+
+
 def test__header_routing_fastapi_init__openapi_passing_nulls__should_not_add_openapi_routes():
     assert [cast("APIRoute", r).path for r in Cadwyn(versions=VersionBundle(Version("2022-11-16"))).routes] == [
         "/docs/oauth2-redirect",
@@ -371,7 +387,7 @@ def test__header_based_versioning(client: TestClient):
     resp = client.get("/v1", headers=BASIC_HEADERS | {"X-API-VERSION": "2024-02-02"})
     assert resp.status_code == 200
     assert resp.json() == {"my_version2": 2}
-    assert resp.headers["X-API-VERSION"] == "2024-02-02"
+    assert resp.headers["X-API-VERSION"] == "2022-02-02"
 
 
 def test__header_based_versioning__invalid_version_header_format__should_raise_422():


### PR DESCRIPTION
Closes #278

Waterfall routing selected the closest supported API version but the middleware echoed the originally requested version in the response header. Preserve the matched router version on the ASGI scope so `x-api-version` reflects the version that handled the request.

Test: `pytest -q tests/test_applications.py` (38 passed)
