### PR TITLE
Harden ty configuration

### DIFF
--- a/.github/workflows/daily_tests.yaml
+++ b/.github/workflows/daily_tests.yaml
@@ -22,12 +22,23 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - run: uv sync --refresh --all-extras --dev --upgrade
       - run: uv run pytest . # We intentionally don't use tox here to run tests "as is"
-      - run: uv run ty version && uv run ty check --exit-zero-on-warning
+
+  update-dependencies-and-typecheck:
+    name: Update dependencies and run typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-python-uv
+        with:
+          # Keep this aligned with ty.toml, tox.ini, and the PR CI typecheck job.
+          python-version: "3.10"
+      - run: uv sync --refresh --all-extras --dev --upgrade
+      - run: tox run -e ty
 
   notify-on-failure:
     name: Notify on failure
     runs-on: ubuntu-latest
-    needs: update-dependencies-and-test
+    needs: [update-dependencies-and-test, update-dependencies-and-typecheck]
     if: failure()
     steps:
       - name: Send Telegram Notification on Failure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Please follow [the Keep a Changelog standard](https://keepachangelog.com/en/1.0.
 ### Changed
 
 - Migrated static type checking from Pyright to ty
+- Hardened ty's static-analysis configuration and fixed the newly exposed typing issues
 
 ## [7.1.0]
 

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,15 @@ if ! command -v $(1) >/dev/null 2>&1; then \
 fi
 endef
 
+define check-tox-runner
+if command -v tox >/dev/null 2>&1 && ! tox config -e ty >/dev/null 2>&1; then \
+		echo "Required tox runner 'uv-venv-lock-runner' was not found."; \
+		echo "Install it with:"; \
+		echo "  uv tool install tox --with tox-uv"; \
+		status=127; \
+fi
+endef
+
 install:
 	uv sync --all-extras --dev
 
@@ -27,7 +36,8 @@ test: check-tools
 check-tools:
 	@status=0; \
 	$(call check-command,prek,uv tool install prek); \
-	$(call check-command,tox,uv tool install tox); \
+	$(call check-command,tox,uv tool install tox --with tox-uv); \
+	$(call check-tox-runner); \
 	exit $$status
 
 check-prek:
@@ -37,5 +47,6 @@ check-prek:
 
 check-tox:
 	@status=0; \
-	$(call check-command,tox,uv tool install tox); \
+	$(call check-command,tox,uv tool install tox --with tox-uv); \
+	$(call check-tox-runner); \
 	exit $$status

--- a/cadwyn/_asts.py
+++ b/cadwyn/_asts.py
@@ -79,11 +79,13 @@ def transform_grouped_metadata(value: "annotated_types.GroupedMetadata", fields:
     )
 
 
-def transform_collection(value: Union[list, tuple, set, frozenset]) -> Any:
+def transform_collection(
+    value: Union[list[object], tuple[object, ...], set[object], frozenset[object]],
+) -> Any:
     return PlainRepr(value.__class__(map(get_fancy_repr, value)))
 
 
-def transform_dict(value: dict) -> Any:
+def transform_dict(value: dict[object, object]) -> Any:
     return PlainRepr(
         value.__class__((get_fancy_repr(k), get_fancy_repr(v)) for k, v in value.items()),
     )

--- a/cadwyn/_render.py
+++ b/cadwyn/_render.py
@@ -83,7 +83,7 @@ def _render_model_from_ast(
         return _render_pydantic_model(wrapper, model_ast)
 
 
-def _render_enum_model(wrapper: _EnumWrapper, original_cls_node: ast.ClassDef):
+def _render_enum_model(wrapper: _EnumWrapper[Enum], original_cls_node: ast.ClassDef):
     # This is for possible schema renaming
     original_cls_node.name = wrapper.cls.__name__
 
@@ -107,7 +107,7 @@ def _render_enum_model(wrapper: _EnumWrapper, original_cls_node: ast.ClassDef):
     return original_cls_node
 
 
-def _render_pydantic_model(wrapper: _PydanticModelWrapper, original_cls_node: ast.ClassDef):
+def _render_pydantic_model(wrapper: _PydanticModelWrapper[BaseModel], original_cls_node: ast.ClassDef):
     # This is for possible schema renaming
     original_cls_node.name = wrapper.name
 

--- a/cadwyn/_utils.py
+++ b/cadwyn/_utils.py
@@ -4,7 +4,7 @@ from inspect import signature
 from typing import TYPE_CHECKING, Any, Concatenate, Generic, TypeVar, Union
 
 from pydantic._internal._decorators import unwrap_wrapped_function
-from typing_extensions import ParamSpec
+from typing_extensions import ParamSpec, override
 
 Sentinel: Any = object()
 
@@ -47,6 +47,7 @@ class classproperty(Generic[_P_T, _P_R]):  # noqa: N801
 class PlainRepr(str):
     """String class where repr doesn't include quotes"""
 
+    @override
     def __repr__(self) -> str:
         return str(self)
 
@@ -61,7 +62,7 @@ def same_method_definition_as_in(
     return decorator
 
 
-def fully_unwrap_decorator(func: Callable, is_pydantic_v1_style_validator: Any):
+def fully_unwrap_decorator(func: Callable[..., object], is_pydantic_v1_style_validator: Any):
     func = unwrap_wrapped_function(func)
     if is_pydantic_v1_style_validator and func.__closure__:
         func = func.__closure__[0].cell_contents

--- a/cadwyn/applications.py
+++ b/cadwyn/applications.py
@@ -26,7 +26,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 from starlette.routing import BaseRoute, Route
 from starlette.types import Lifespan
-from typing_extensions import Self, assert_never, deprecated
+from typing_extensions import Self, assert_never, deprecated, override
 
 from cadwyn._utils import DATACLASS_SLOTS, same_method_definition_as_in
 from cadwyn.changelogs import CadwynChangelogResource, _generate_changelog
@@ -294,6 +294,7 @@ class Cadwyn(FastAPI):
             )
 
     @same_method_definition_as_in(FastAPI.__call__)
+    @override
     async def __call__(self, *args: Any, **kwargs: Any) -> None:
         if not self._cadwyn_initialized:
             self._cadwyn_initialize()
@@ -438,7 +439,7 @@ class Cadwyn(FastAPI):
             for route, effective_route_context in _iter_routes_with_context(self.router.unversioned_routes)
         )
 
-    def _filter_openapi_tags(self, routes: list) -> Union[list[dict[str, Any]], None]:
+    def _filter_openapi_tags(self, routes: list[BaseRoute]) -> Union[list[dict[str, Any]], None]:
         if not self.openapi_tags:
             return self.openapi_tags
         used_tags: set[str | Enum] = set()

--- a/cadwyn/changelogs.py
+++ b/cadwyn/changelogs.py
@@ -48,21 +48,13 @@ _logger = getLogger(__name__)
 T = TypeVar("T", bound=Union[PossibleInstructions, type[VersionChange]])
 
 
-def _hide_instruction(instruction: _HiddenAttributeMixin) -> None:
-    instruction.is_hidden_from_changelog = True
-
-
-def _hide_version_change(version_change: type[VersionChange]) -> None:
-    version_change.is_hidden_from_changelog = True
-
-
 def hidden(instruction_or_version_change: T) -> T:
     if isinstance(instruction_or_version_change, _HiddenAttributeMixin):
-        _hide_instruction(instruction_or_version_change)
+        cast("_HiddenAttributeMixin", instruction_or_version_change).is_hidden_from_changelog = True
         return instruction_or_version_change
 
     if isinstance(instruction_or_version_change, type) and issubclass(instruction_or_version_change, VersionChange):
-        _hide_version_change(instruction_or_version_change)
+        cast("type[VersionChange]", instruction_or_version_change).is_hidden_from_changelog = True
     return instruction_or_version_change
 
 

--- a/cadwyn/changelogs.py
+++ b/cadwyn/changelogs.py
@@ -19,6 +19,7 @@ from cadwyn._utils import Sentinel
 from cadwyn.route_generation import _get_routes
 from cadwyn.routing import _RootCadwynAPIRouter
 from cadwyn.schema_generation import SchemaGenerator, _change_field_in_model, generate_versioned_models
+from cadwyn.structure.common import _HiddenAttributeMixin
 from cadwyn.structure.versions import PossibleInstructions, VersionBundle, VersionChange, VersionChangeWithSideEffects
 
 from .structure.endpoints import (
@@ -47,13 +48,21 @@ _logger = getLogger(__name__)
 T = TypeVar("T", bound=Union[PossibleInstructions, type[VersionChange]])
 
 
+def _hide_instruction(instruction: _HiddenAttributeMixin) -> None:
+    instruction.is_hidden_from_changelog = True
+
+
+def _hide_version_change(version_change: type[VersionChange]) -> None:
+    version_change.is_hidden_from_changelog = True
+
+
 def hidden(instruction_or_version_change: T) -> T:
-    if isinstance(
-        instruction_or_version_change, staticmethod | ValidatorDidntExistInstruction | ValidatorExistedInstruction
-    ):
+    if isinstance(instruction_or_version_change, _HiddenAttributeMixin):
+        _hide_instruction(instruction_or_version_change)
         return instruction_or_version_change
 
-    instruction_or_version_change.is_hidden_from_changelog = True
+    if isinstance(instruction_or_version_change, type) and issubclass(instruction_or_version_change, VersionChange):
+        _hide_version_change(instruction_or_version_change)
     return instruction_or_version_change
 
 
@@ -151,7 +160,7 @@ def _get_all_pydantic_models_from_generic(annotation: Any) -> list[type[BaseMode
     return models
 
 
-def _get_openapi_representation_of_a_field(model: type[BaseModel], field_name: str) -> dict:
+def _get_openapi_representation_of_a_field(model: type[BaseModel], field_name: str) -> dict[str, object]:
     class CadwynDummyModelForRepresentation(BaseModel):
         my_field: model  # ty: ignore[invalid-type-form]
 

--- a/cadwyn/changelogs.py
+++ b/cadwyn/changelogs.py
@@ -50,7 +50,8 @@ T = TypeVar("T", bound=Union[PossibleInstructions, type[VersionChange]])
 
 def hidden(instruction_or_version_change: T) -> T:
     if isinstance(instruction_or_version_change, _HiddenAttributeMixin):
-        cast("_HiddenAttributeMixin", instruction_or_version_change).is_hidden_from_changelog = True
+        # Weird ty bug, or I am dumb.
+        instruction_or_version_change.is_hidden_from_changelog = True  # ty: ignore[possibly-missing-attribute]
         return instruction_or_version_change
 
     if isinstance(instruction_or_version_change, type) and issubclass(instruction_or_version_change, VersionChange):

--- a/cadwyn/middleware.py
+++ b/cadwyn/middleware.py
@@ -11,6 +11,7 @@ import fastapi
 from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware, DispatchFunction, RequestResponseEndpoint
 from starlette.types import ASGIApp
+from typing_extensions import override
 
 from cadwyn._internal.context_vars import DEFAULT_API_VERSION_VAR
 from cadwyn.structure.common import VersionType
@@ -103,6 +104,7 @@ class VersionPickingMiddleware(BaseHTTPMiddleware):
         self.api_version_var = api_version_var
         self.api_version_default_value = api_version_default_value
 
+    @override
     async def dispatch(
         self,
         request: Request,

--- a/cadwyn/routing.py
+++ b/cadwyn/routing.py
@@ -10,6 +10,7 @@ from starlette.datastructures import URL
 from starlette.responses import RedirectResponse
 from starlette.routing import BaseRoute, Match
 from starlette.types import Receive, Scope, Send
+from typing_extensions import override
 
 from cadwyn._internal.context_vars import DEFAULT_API_VERSION_VAR
 from cadwyn._utils import same_method_definition_as_in
@@ -64,6 +65,7 @@ class _RootCadwynAPIRouter(APIRouter):
             return self.versioned_routers[picked_version].routes
         return []  # pragma: no cover # This should not be possible
 
+    @override
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if "router" not in scope:  # pragma: no cover
             scope["router"] = self
@@ -97,11 +99,13 @@ class _RootCadwynAPIRouter(APIRouter):
         return sorted(self.versioned_routers.keys())
 
     @same_method_definition_as_in(APIRouter.add_api_route)
+    @override
     def add_api_route(self, *args: Any, **kwargs: Any):
         super().add_api_route(*args, **kwargs)
         self.unversioned_routes.append(self.routes[-1])
 
     @same_method_definition_as_in(APIRouter.include_router)
+    @override
     def include_router(self, *args: Any, **kwargs: Any):
         routes_before = len(self.routes)
         unversioned_routes_before = len(self.unversioned_routes)
@@ -110,21 +114,25 @@ class _RootCadwynAPIRouter(APIRouter):
             self.unversioned_routes.extend(self.routes[routes_before:])
 
     @same_method_definition_as_in(APIRouter.add_route)
+    @override
     def add_route(self, *args: Any, **kwargs: Any):
         super().add_route(*args, **kwargs)
         self.unversioned_routes.append(self.routes[-1])
 
     @same_method_definition_as_in(APIRouter.mount)
+    @override
     def mount(self, *args: Any, **kwargs: Any):
         super().mount(*args, **kwargs)
         self.unversioned_routes.append(self.routes[-1])
 
     @same_method_definition_as_in(APIRouter.add_api_websocket_route)
+    @override
     def add_api_websocket_route(self, *args: Any, **kwargs: Any):  # pragma: no cover
         super().add_api_websocket_route(*args, **kwargs)
         self.unversioned_routes.append(self.routes[-1])
 
     @same_method_definition_as_in(APIRouter.add_websocket_route)
+    @override
     def add_websocket_route(self, *args: Any, **kwargs: Any):  # pragma: no cover
         super().add_websocket_route(*args, **kwargs)
         self.unversioned_routes.append(self.routes[-1])

--- a/cadwyn/schema_generation.py
+++ b/cadwyn/schema_generation.py
@@ -51,6 +51,7 @@ from typing_extensions import (
     assert_never,
     final,
     overload,
+    override,
 )
 
 from cadwyn._asts import GenericAliasUnionArgs
@@ -164,8 +165,8 @@ def _extract_passed_field_attributes(field_info: FieldInfo) -> dict[str, object]
 
 @dataclasses.dataclass(**DATACLASS_SLOTS)
 class _ModelBundle:
-    enums: dict[type[Enum], "_EnumWrapper"]
-    schemas: dict[type[BaseModel], "_PydanticModelWrapper"]
+    enums: dict[type[Enum], "_EnumWrapper[Enum]"]
+    schemas: dict[type[BaseModel], "_PydanticModelWrapper[BaseModel]"]
 
 
 @dataclasses.dataclass(**DATACLASS_SLOTS, **DATACLASS_KW_ONLY)
@@ -219,8 +220,8 @@ def _unwrap_model(model: type[_T_ANY_MODEL]) -> type[_T_ANY_MODEL]:
 @dataclasses.dataclass(**DATACLASS_SLOTS, **DATACLASS_KW_ONLY)
 class _ValidatorWrapper:
     kwargs: dict[str, Any]
-    func: Callable
-    decorator: Callable
+    func: Callable[..., object]
+    decorator: Callable[..., Callable[..., object]]
     is_deleted: bool = False
 
 
@@ -229,7 +230,11 @@ class _PerFieldValidatorWrapper(_ValidatorWrapper):
     fields: list[str] = dataclasses.field(default_factory=list)
 
 
-def _wrap_validator(func: Callable, is_pydantic_v1_style_validator: Any, decorator_info: _decorators.DecoratorInfo):
+def _wrap_validator(
+    func: Callable[..., object],
+    is_pydantic_v1_style_validator: Any,
+    decorator_info: _decorators.DecoratorInfo,
+):
     # This is only for pydantic v1 style validators
     func = fully_unwrap_decorator(func, is_pydantic_v1_style_validator)
     if inspect.ismethod(func):
@@ -371,6 +376,7 @@ class _PydanticModelWrapper(Generic[_T_PYDANTIC_MODEL]):
         memo[id(self)] = result
         return result
 
+    @override
     def __hash__(self) -> int:
         return hash(id(self))
 
@@ -483,24 +489,29 @@ class _CallableWrapper:
     def __call__(self, *args: Any, **kwargs: Any):
         return self._original_callable(*args, **kwargs)
 
+    @override
     def __hash__(self):
         return hash(self._original_callable)
 
+    @override
     def __eq__(self, value: object) -> bool:
         return self._original_callable == value
 
 
 class _AsyncCallableWrapper(_CallableWrapper):
+    @override
     async def __call__(self, *args: Any, **kwargs: Any):
         return await self._original_callable(*args, **kwargs)
 
 
 class _GeneratorCallableWrapper(_CallableWrapper):
+    @override
     def __call__(self, *args: Any, **kwargs: Any):  # pragma: no cover
         yield from self._original_callable(*args, **kwargs)
 
 
 class _AsyncGeneratorCallableWrapper(_CallableWrapper):
+    @override
     async def __call__(self, *args: Any, **kwargs: Any):  # pragma: no cover
         async for value in self._original_callable(*args, **kwargs):
             yield value
@@ -731,7 +742,7 @@ class _AnnotationTransformer:
         return call
 
 
-def is_gen_callable(call: Callable) -> bool:
+def is_gen_callable(call: Callable[..., object]) -> bool:
     # Copied from fastapi.dependencies.models
     if inspect.isgeneratorfunction(call):
         return True
@@ -739,7 +750,7 @@ def is_gen_callable(call: Callable) -> bool:
     return inspect.isgeneratorfunction(dunder_call)
 
 
-def is_async_gen_callable(call: Callable) -> bool:
+def is_async_gen_callable(call: Callable[..., object]) -> bool:
     # Copied from fastapi.dependencies.models
     if inspect.isasyncgenfunction(call):
         return True
@@ -747,7 +758,7 @@ def is_async_gen_callable(call: Callable) -> bool:
     return inspect.isasyncgenfunction(dunder_call)
 
 
-def is_coroutine_callable(call: Callable) -> bool:  # pragma: no cover
+def is_coroutine_callable(call: Callable[..., object]) -> bool:  # pragma: no cover
     # Copied from fastapi.dependencies.models
     if inspect.isroutine(call):
         return iscoroutinefunction(call)
@@ -787,11 +798,11 @@ class SchemaGenerator:
         model = _unwrap_model(model)
 
         if model in self.concrete_models:
-            return self.concrete_models[model]
-
-        wrapper = self._get_wrapper_for_model(model)
-        model_copy = wrapper.generate_model_copy(self)
-        self.concrete_models[model] = model_copy
+            model_copy = self.concrete_models[model]
+        else:
+            wrapper = self._get_wrapper_for_model(model)
+            model_copy = wrapper.generate_model_copy(self)
+            self.concrete_models[model] = model_copy
         return cast("type[_T_ANY_MODEL]", model_copy)
 
     @overload
@@ -880,7 +891,8 @@ def _apply_alter_schema_instructions(
         elif isinstance(alter_schema_instruction, ValidatorExistedInstruction):
             validator_name = get_name_of_function_wrapped_in_pydantic_validator(alter_schema_instruction.validator)
             raw_validator = cast(
-                "pydantic._internal._decorators.PydanticDescriptorProxy", alter_schema_instruction.validator
+                "pydantic._internal._decorators.PydanticDescriptorProxy[object]",
+                alter_schema_instruction.validator,
             )
             schema_info.validators[validator_name] = _wrap_validator(
                 raw_validator.wrapped,
@@ -933,7 +945,7 @@ def _apply_alter_enum_instructions(
 
 
 def _change_model(
-    model: _PydanticModelWrapper,
+    model: _PydanticModelWrapper[BaseModel],
     alter_schema_instruction: SchemaHadInstruction,
     version_change_name: str,
 ):
@@ -947,7 +959,7 @@ def _change_model(
 
 
 def _add_field_to_model(
-    model: _PydanticModelWrapper,
+    model: _PydanticModelWrapper[BaseModel],
     schemas: "dict[type[BaseModel], _PydanticModelWrapper[BaseModel]]",
     alter_schema_instruction: FieldExistedAsInstruction,
     version_change_name: str,
@@ -976,7 +988,7 @@ def _add_field_to_model(
 
 
 def _change_field_in_model(
-    model: _PydanticModelWrapper,
+    model: _PydanticModelWrapper[BaseModel],
     schemas: "dict[type[BaseModel], _PydanticModelWrapper[BaseModel]]",
     alter_schema_instruction: Union[FieldHadInstruction, FieldDidntHaveInstruction],
     version_change_name: str,
@@ -1014,7 +1026,7 @@ def _change_field_in_model(
 
 
 def _change_field(
-    model: _PydanticModelWrapper,
+    model: _PydanticModelWrapper[BaseModel],
     alter_schema_instruction: FieldHadInstruction,
     version_change_name: str,
     defined_annotations: dict[str, Any],
@@ -1058,7 +1070,7 @@ def _change_field(
 
 
 def _delete_field_attributes(
-    model: _PydanticModelWrapper,
+    model: _PydanticModelWrapper[BaseModel],
     alter_schema_instruction: FieldDidntHaveInstruction,
     version_change_name: str,
     field: PydanticFieldWrapper,
@@ -1085,7 +1097,7 @@ def _delete_field_attributes(
             )
 
 
-def _delete_field_from_model(model: _PydanticModelWrapper, field_name: str, version_change_name: str):
+def _delete_field_from_model(model: _PydanticModelWrapper[BaseModel], field_name: str, version_change_name: str):
     if field_name in model.fields:
         model.fields.pop(field_name)
         model.annotations.pop(field_name)

--- a/cadwyn/structure/data.py
+++ b/cadwyn/structure/data.py
@@ -2,7 +2,7 @@ import functools
 import inspect
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import ClassVar, Union
+from typing import ClassVar, Union, cast
 
 from fastapi import Request, Response
 from starlette.datastructures import FormData, MutableHeaders, UploadFile
@@ -157,11 +157,9 @@ def convert_request_to_next_version_for(
         transformer: Callable[[RequestInfo], None],
     ) -> Union[_AlterRequestBySchemaInstruction, _AlterRequestByPathInstruction]:
         if isinstance(schema_or_path, str):
-            if not isinstance(methods_or_second_schema, list):  # pragma: no cover
-                raise TypeError("Decorator arguments were validated above")
             return _AlterRequestByPathInstruction(
                 path=schema_or_path,
-                methods=set(methods_or_second_schema),
+                methods=set(cast("list[str]", methods_or_second_schema)),
                 transformer=transformer,
             )
         else:
@@ -248,11 +246,9 @@ def convert_response_to_previous_version_for(
     ) -> Union[_AlterResponseBySchemaInstruction, _AlterResponseByPathInstruction]:
         if isinstance(schema_or_path, str):
             # The validation above checks that methods is not None
-            if not isinstance(methods_or_second_schema, list):  # pragma: no cover
-                raise TypeError("Decorator arguments were validated above")
             return _AlterResponseByPathInstruction(
                 path=schema_or_path,
-                methods=set(methods_or_second_schema),
+                methods=set(cast("list[str]", methods_or_second_schema)),
                 transformer=transformer,
                 migrate_http_errors=migrate_http_errors,
             )

--- a/cadwyn/structure/data.py
+++ b/cadwyn/structure/data.py
@@ -2,7 +2,7 @@ import functools
 import inspect
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import ClassVar, Union, cast
+from typing import ClassVar, Union
 
 from fastapi import Request, Response
 from starlette.datastructures import FormData, MutableHeaders, UploadFile
@@ -157,9 +157,11 @@ def convert_request_to_next_version_for(
         transformer: Callable[[RequestInfo], None],
     ) -> Union[_AlterRequestBySchemaInstruction, _AlterRequestByPathInstruction]:
         if isinstance(schema_or_path, str):
+            if not isinstance(methods_or_second_schema, list):  # pragma: no cover
+                raise TypeError("Decorator arguments were validated above")
             return _AlterRequestByPathInstruction(
                 path=schema_or_path,
-                methods=set(cast("list", methods_or_second_schema)),
+                methods=set(methods_or_second_schema),
                 transformer=transformer,
             )
         else:
@@ -246,9 +248,11 @@ def convert_response_to_previous_version_for(
     ) -> Union[_AlterResponseBySchemaInstruction, _AlterResponseByPathInstruction]:
         if isinstance(schema_or_path, str):
             # The validation above checks that methods is not None
+            if not isinstance(methods_or_second_schema, list):  # pragma: no cover
+                raise TypeError("Decorator arguments were validated above")
             return _AlterResponseByPathInstruction(
                 path=schema_or_path,
-                methods=set(cast("list", methods_or_second_schema)),
+                methods=set(methods_or_second_schema),
                 transformer=transformer,
                 migrate_http_errors=migrate_http_errors,
             )

--- a/cadwyn/structure/schemas.py
+++ b/cadwyn/structure/schemas.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, Literal, TypeAlias, TypeVar, Union, cast
 
 from pydantic import AliasChoices, AliasPath, BaseModel, Field
 from pydantic._internal._decorators import PydanticDescriptorProxy, unwrap_wrapped_function
@@ -61,6 +61,7 @@ PossibleFieldAttributes = Literal[
 ]
 
 _ValidatorReturnT = TypeVar("_ValidatorReturnT")
+_ValidatorReference: TypeAlias = Union[Callable[..., object], PydanticDescriptorProxy[object]]
 
 
 # TODO: Add json_schema_extra as a breaking change in a major version
@@ -271,7 +272,7 @@ def _get_model_decorators(model: type[BaseModel]):
 @dataclass(**DATACLASS_SLOTS)
 class ValidatorExistedInstruction:
     schema: type[BaseModel]
-    validator: object
+    validator: _ValidatorReference
 
 
 @dataclass(**DATACLASS_SLOTS)
@@ -283,7 +284,7 @@ class ValidatorDidntExistInstruction:
 @dataclass(**DATACLASS_SLOTS)
 class AlterValidatorInstructionFactory:
     schema: type[BaseModel]
-    func: object
+    func: _ValidatorReference
 
     @property
     def existed(self) -> ValidatorExistedInstruction:
@@ -326,20 +327,20 @@ class AlterSchemaInstructionFactory:
     ) -> AlterValidatorInstructionFactory:
         func = unwrap_wrapped_function(func)
 
-        if not isinstance(func, PydanticDescriptorProxy):
-            if hasattr(func, "__self__"):
-                owner = func.__self__
-                if (
-                    isinstance(owner, type)
-                    and issubclass(owner, BaseModel)
-                    and any(  # pragma: no branch
-                        fully_unwrap_decorator(decorator.func, decorator.shim) == func
-                        for decorator in _get_model_decorators(owner)
-                    )
-                ):
-                    return AlterValidatorInstructionFactory(self.schema, func)
-            raise CadwynStructureError("The passed function must be a pydantic validator")
-        return AlterValidatorInstructionFactory(self.schema, func)
+        if isinstance(func, PydanticDescriptorProxy):
+            return AlterValidatorInstructionFactory(self.schema, func)
+        if hasattr(func, "__self__"):
+            owner = func.__self__
+            if (
+                isinstance(owner, type)
+                and issubclass(owner, BaseModel)
+                and any(  # pragma: no branch
+                    fully_unwrap_decorator(decorator.func, decorator.shim) == func
+                    for decorator in _get_model_decorators(owner)
+                )
+            ):
+                return AlterValidatorInstructionFactory(self.schema, cast("Callable[..., object]", func))
+        raise CadwynStructureError("The passed function must be a pydantic validator")
 
     def had(self, *, name: str) -> SchemaHadInstruction:
         return SchemaHadInstruction(is_hidden_from_changelog=False, schema=self.schema, name=name)

--- a/cadwyn/structure/schemas.py
+++ b/cadwyn/structure/schemas.py
@@ -271,7 +271,7 @@ def _get_model_decorators(model: type[BaseModel]):
 @dataclass(**DATACLASS_SLOTS)
 class ValidatorExistedInstruction:
     schema: type[BaseModel]
-    validator: Union[Callable[..., Any], PydanticDescriptorProxy[object]]
+    validator: object
 
 
 @dataclass(**DATACLASS_SLOTS)
@@ -283,7 +283,7 @@ class ValidatorDidntExistInstruction:
 @dataclass(**DATACLASS_SLOTS)
 class AlterValidatorInstructionFactory:
     schema: type[BaseModel]
-    func: Union[Callable[..., Any], PydanticDescriptorProxy[object]]
+    func: object
 
     @property
     def existed(self) -> ValidatorExistedInstruction:
@@ -324,24 +324,22 @@ class AlterSchemaInstructionFactory:
         func: "Union[Callable[..., Any], classmethod[Any, Any, Any], PydanticDescriptorProxy[_ValidatorReturnT]]",
         /,
     ) -> AlterValidatorInstructionFactory:
-        unwrapped_func = cast(
-            "Union[Callable[..., Any], PydanticDescriptorProxy[object]]", unwrap_wrapped_function(func)
-        )
+        func = unwrap_wrapped_function(func)
 
-        if not isinstance(unwrapped_func, PydanticDescriptorProxy):
-            if hasattr(unwrapped_func, "__self__"):
-                owner = unwrapped_func.__self__
+        if not isinstance(func, PydanticDescriptorProxy):
+            if hasattr(func, "__self__"):
+                owner = func.__self__
                 if (
                     isinstance(owner, type)
                     and issubclass(owner, BaseModel)
                     and any(  # pragma: no branch
-                        fully_unwrap_decorator(decorator.func, decorator.shim) == unwrapped_func
+                        fully_unwrap_decorator(decorator.func, decorator.shim) == func
                         for decorator in _get_model_decorators(owner)
                     )
                 ):
-                    return AlterValidatorInstructionFactory(self.schema, unwrapped_func)
+                    return AlterValidatorInstructionFactory(self.schema, func)
             raise CadwynStructureError("The passed function must be a pydantic validator")
-        return AlterValidatorInstructionFactory(self.schema, unwrapped_func)
+        return AlterValidatorInstructionFactory(self.schema, func)
 
     def had(self, *, name: str) -> SchemaHadInstruction:
         return SchemaHadInstruction(is_hidden_from_changelog=False, schema=self.schema, name=name)

--- a/cadwyn/structure/schemas.py
+++ b/cadwyn/structure/schemas.py
@@ -271,7 +271,7 @@ def _get_model_decorators(model: type[BaseModel]):
 @dataclass(**DATACLASS_SLOTS)
 class ValidatorExistedInstruction:
     schema: type[BaseModel]
-    validator: object
+    validator: Union[Callable[..., Any], PydanticDescriptorProxy[object]]
 
 
 @dataclass(**DATACLASS_SLOTS)
@@ -283,7 +283,7 @@ class ValidatorDidntExistInstruction:
 @dataclass(**DATACLASS_SLOTS)
 class AlterValidatorInstructionFactory:
     schema: type[BaseModel]
-    func: object
+    func: Union[Callable[..., Any], PydanticDescriptorProxy[object]]
 
     @property
     def existed(self) -> ValidatorExistedInstruction:
@@ -324,22 +324,24 @@ class AlterSchemaInstructionFactory:
         func: "Union[Callable[..., Any], classmethod[Any, Any, Any], PydanticDescriptorProxy[_ValidatorReturnT]]",
         /,
     ) -> AlterValidatorInstructionFactory:
-        func = unwrap_wrapped_function(func)
+        unwrapped_func = cast(
+            "Union[Callable[..., Any], PydanticDescriptorProxy[object]]", unwrap_wrapped_function(func)
+        )
 
-        if not isinstance(func, PydanticDescriptorProxy):
-            if hasattr(func, "__self__"):
-                owner = func.__self__
+        if not isinstance(unwrapped_func, PydanticDescriptorProxy):
+            if hasattr(unwrapped_func, "__self__"):
+                owner = unwrapped_func.__self__
                 if (
                     isinstance(owner, type)
                     and issubclass(owner, BaseModel)
                     and any(  # pragma: no branch
-                        fully_unwrap_decorator(decorator.func, decorator.shim) == func
+                        fully_unwrap_decorator(decorator.func, decorator.shim) == unwrapped_func
                         for decorator in _get_model_decorators(owner)
                     )
                 ):
-                    return AlterValidatorInstructionFactory(self.schema, func)
+                    return AlterValidatorInstructionFactory(self.schema, unwrapped_func)
             raise CadwynStructureError("The passed function must be a pydantic validator")
-        return AlterValidatorInstructionFactory(self.schema, func)
+        return AlterValidatorInstructionFactory(self.schema, unwrapped_func)
 
     def had(self, *, name: str) -> SchemaHadInstruction:
         return SchemaHadInstruction(is_hidden_from_changelog=False, schema=self.schema, name=name)

--- a/cadwyn/structure/schemas.py
+++ b/cadwyn/structure/schemas.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal, Union, cast
+from typing import TYPE_CHECKING, Any, Literal, TypeVar, Union, cast
 
 from pydantic import AliasChoices, AliasPath, BaseModel, Field
 from pydantic._internal._decorators import PydanticDescriptorProxy, unwrap_wrapped_function
@@ -59,6 +59,8 @@ PossibleFieldAttributes = Literal[
     "discriminator",
     "json_schema_extra",
 ]
+
+_ValidatorReturnT = TypeVar("_ValidatorReturnT")
 
 
 # TODO: Add json_schema_extra as a breaking change in a major version
@@ -145,7 +147,7 @@ class AlterFieldInstructionFactory:
         type: Any = Sentinel,
         default: Any = Sentinel,
         alias: Union[str, None] = Sentinel,
-        default_factory: Callable = Sentinel,
+        default_factory: Callable[[], object] = Sentinel,
         alias_priority: Union[int, None] = Sentinel,
         validation_alias: Union[str, AliasPath, AliasChoices, None] = Sentinel,
         serialization_alias: Union[str, None] = Sentinel,
@@ -269,7 +271,7 @@ def _get_model_decorators(model: type[BaseModel]):
 @dataclass(**DATACLASS_SLOTS)
 class ValidatorExistedInstruction:
     schema: type[BaseModel]
-    validator: Union[Callable[..., Any], PydanticDescriptorProxy]
+    validator: object
 
 
 @dataclass(**DATACLASS_SLOTS)
@@ -281,7 +283,7 @@ class ValidatorDidntExistInstruction:
 @dataclass(**DATACLASS_SLOTS)
 class AlterValidatorInstructionFactory:
     schema: type[BaseModel]
-    func: Union[Callable[..., Any], PydanticDescriptorProxy]
+    func: object
 
     @property
     def existed(self) -> ValidatorExistedInstruction:
@@ -318,9 +320,11 @@ class AlterSchemaInstructionFactory:
         return AlterFieldInstructionFactory(self.schema, name)
 
     def validator(
-        self, func: "Union[Callable[..., Any], classmethod[Any, Any, Any], PydanticDescriptorProxy]", /
+        self,
+        func: "Union[Callable[..., Any], classmethod[Any, Any, Any], PydanticDescriptorProxy[_ValidatorReturnT]]",
+        /,
     ) -> AlterValidatorInstructionFactory:
-        func = cast("Union[Callable[..., Any], PydanticDescriptorProxy]", unwrap_wrapped_function(func))
+        func = unwrap_wrapped_function(func)
 
         if not isinstance(func, PydanticDescriptorProxy):
             if hasattr(func, "__self__"):

--- a/cadwyn/structure/versions.py
+++ b/cadwyn/structure/versions.py
@@ -56,6 +56,7 @@ _P = ParamSpec("_P")
 _R = TypeVar("_R")
 _RouteId = int
 
+# ty requires staticmethod's type arguments, but runtime isinstance() requires the bare class.
 if TYPE_CHECKING:
     _StaticMethodInstruction: TypeAlias = staticmethod[..., object]
 else:

--- a/cadwyn/structure/versions.py
+++ b/cadwyn/structure/versions.py
@@ -57,7 +57,6 @@ _R = TypeVar("_R")
 _RouteId = int
 
 if TYPE_CHECKING:
-    # ty requires staticmethod's type arguments, but the runtime alias must stay unsubscripted for isinstance().
     _StaticMethodInstruction: TypeAlias = staticmethod[..., object]
 else:
     _StaticMethodInstruction = staticmethod

--- a/cadwyn/structure/versions.py
+++ b/cadwyn/structure/versions.py
@@ -25,7 +25,7 @@ from pydantic import BaseModel
 from pydantic_core import PydanticUndefined
 from starlette._utils import is_async_callable
 from starlette.datastructures import FormData
-from typing_extensions import Any, ParamSpec, TypeVar, assert_never, deprecated
+from typing_extensions import Any, ParamSpec, TypeVar, assert_never, deprecated, override
 
 from cadwyn._internal.context_vars import CURRENT_DEPENDENCY_SOLVER_VAR
 from cadwyn._utils import classproperty
@@ -56,8 +56,17 @@ _P = ParamSpec("_P")
 _R = TypeVar("_R")
 _RouteId = int
 
+if TYPE_CHECKING:
+    _StaticMethodInstruction: TypeAlias = staticmethod[..., object]
+else:
+    _StaticMethodInstruction = staticmethod
+
 PossibleInstructions: TypeAlias = Union[
-    AlterSchemaSubInstruction, AlterEndpointSubInstruction, AlterEnumSubInstruction, SchemaHadInstruction, staticmethod
+    AlterSchemaSubInstruction,
+    AlterEndpointSubInstruction,
+    AlterEnumSubInstruction,
+    SchemaHadInstruction,
+    _StaticMethodInstruction,
 ]
 
 
@@ -118,7 +127,7 @@ else:
 
 class VersionChange:
     description: ClassVar[str] = Sentinel
-    is_hidden_from_changelog: bool = False
+    is_hidden_from_changelog: ClassVar[bool] = False
     instructions_to_migrate_to_previous_version: ClassVar[Sequence[PossibleInstructions]] = Sentinel
     alter_schema_instructions: ClassVar[list[Union[AlterSchemaSubInstruction, SchemaHadInstruction]]] = Sentinel
     alter_enum_instructions: ClassVar[list[AlterEnumSubInstruction]] = Sentinel
@@ -239,6 +248,7 @@ class VersionChange:
 
 class VersionChangeWithSideEffects(VersionChange, _abstract=True):
     @classmethod
+    @override
     def _check_no_subclassing(cls):
         if cls.mro() != [cls, VersionChangeWithSideEffects, VersionChange, object]:
             raise TypeError(
@@ -274,6 +284,7 @@ class Version:
     def version_changes(self):  # pragma: no cover
         return self.changes
 
+    @override
     def __repr__(self) -> str:
         return f"Version('{self.value}')"
 
@@ -788,7 +799,7 @@ async def _get_body(
 
 
 def _add_keyword_only_parameter(
-    func: Callable,
+    func: Callable[..., object],
     param_name: str,
     param_annotation: type,
 ):

--- a/cadwyn/structure/versions.py
+++ b/cadwyn/structure/versions.py
@@ -57,6 +57,7 @@ _R = TypeVar("_R")
 _RouteId = int
 
 if TYPE_CHECKING:
+    # ty requires staticmethod's type arguments, but the runtime alias must stay unsubscripted for isinstance().
     _StaticMethodInstruction: TypeAlias = staticmethod[..., object]
 else:
     _StaticMethodInstruction = staticmethod

--- a/docs/home/CONTRIBUTING.md
+++ b/docs/home/CONTRIBUTING.md
@@ -7,7 +7,7 @@
 * We maintain a Makefile with several commands to help with common tasks
 
 1. Install [uv](https://docs.astral.sh/uv/)
-2. Install the standalone developer tools with `uv tool install prek` and `uv tool install tox`
+2. Install the standalone developer tools with `uv tool install prek` and `uv tool install tox --with tox-uv`
 3. Run `uv sync` to create a virtual environment and install the dependencies
 4. Install [prek](https://prek.j178.dev/) hooks with `prek install -f`
 5. Run `make check` to verify that the local CI-equivalent checks pass
@@ -43,11 +43,11 @@ tests for `cadwyn/codegen.py` reside in `tests/codegen`.
 
 `make check` runs the local CI-equivalent suite with tox's default automatic
 parallelism. It runs the supported Python test matrix, tutorial tests, coverage,
-prek linting, documentation build, link validation, pyright, and package build
+prek linting, documentation build, link validation, ty, and package build
 checks.
 
-If `prek` or `tox` is missing, the Makefile will stop early and print the
-matching `uv tool install ...` command to install it.
+If `prek`, `tox`, or the `tox-uv` plugin is missing, the Makefile will stop
+early and print the matching `uv tool install ...` command to install it.
 
 `make test` runs the same full check suite.
 
@@ -56,7 +56,7 @@ matching `uv tool install ...` command to install it.
 We use [ty](https://github.com/astral-sh/ty) to enforce type safety.
 You can run it with:
 
-`uv run ty check --exit-zero-on-warning`
+`tox run -e ty`
 
 ## Project documentation
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter, FastAPI
 from fastapi.testclient import TestClient
 from pydantic import BaseModel
 from pytest_fixture_classes import fixture_class
+from typing_extensions import override
 
 from cadwyn import Cadwyn, VersionBundle, VersionedAPIRouter
 from cadwyn._utils import same_method_definition_as_in
@@ -56,6 +57,7 @@ class TestClientWithHardcodedAPIVersion(CadwynTestClient):
         self.api_version_var = api_version_var
         self.api_version = api_version
 
+    @override
     def request(self, *args, **kwargs):
         if self.api_version is not Undefined and self.api_version_var:
             self.api_version_var.set(self.api_version)

--- a/tox.ini
+++ b/tox.ini
@@ -90,7 +90,7 @@ commands =
 base_python = py3.10
 package = skip
 skip_install = true
-commands = ty check --exit-zero-on-warning
+commands = ty check
 
 
 [testenv:build]

--- a/ty.toml
+++ b/ty.toml
@@ -1,8 +1,25 @@
 [environment]
+python-platform = "all"
 python-version = "3.10"
+
+[analysis]
+respect-type-ignore-comments = false
+strict-literal-narrowing = true
+
+[rules]
+blanket-ignore-comment = "error"
+division-by-zero = "error"
+missing-override-decorator = "error"
+missing-type-argument = "error"
+possibly-missing-attribute = "error"
+possibly-missing-import = "error"
+possibly-unresolved-reference = "error"
+unsupported-dynamic-base = "error"
 
 [[overrides]]
 include = ["tests/**"]
 
 [overrides.rules]
+missing-type-argument = "ignore"
+possibly-missing-attribute = "ignore"
 unsupported-base = "ignore"


### PR DESCRIPTION
## Summary

- make ty fail on warnings and enable stricter diagnostics for overrides, generics, platform compatibility, and potentially unresolved types
- tighten the affected annotations and runtime narrowing across Cadwyn, including schema generation
- run dependency-update type checking in its own CI job and make the local tox requirements explicit
- document the stricter checking in the changelog and contributor guide

## Why

The initial Pyright-to-ty migration kept a permissive warning mode and a minimal rule set. Enabling the stricter rules exposed incomplete generic annotations, broad callable types, missing override markers, and a few places where runtime narrowing was implicit. This change fixes those issues instead of suppressing them.

This is a developer-tooling and typing-only change; it does not intentionally change Cadwyn's public runtime behavior.

## Validation

- `tox run -e ty`
- `uv run pytest -q` (379 passed)
- `prek run --all-files`
- `make check-tools`
