### PR TITLE
Clarify contributor setup commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Please follow [the Keep a Changelog standard](https://keepachangelog.com/en/1.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Simplified contributor setup and development commands (#387)
+
 ## [7.1.1]
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 SHELL := /bin/bash
 py_warn = PYTHONDEVMODE=1
+.DEFAULT_GOAL := help
 
-.PHONY: install lint check test check-tools check-prek check-tox
+.PHONY: help install hooks lint check check-tools check-prek
+
+help: ## Show the available developer commands
+	@awk 'BEGIN {FS = ":.*##"; printf "Usage:\n  make <target>\n\nTargets:\n"} /^[a-zA-Z0-9_-]+:.*?##/ {printf "  %-12s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
 define check-command
 if ! command -v $(1) >/dev/null 2>&1; then \
@@ -21,16 +25,18 @@ if command -v tox >/dev/null 2>&1 && ! tox config -e py3.10 >/dev/null 2>&1; the
 fi
 endef
 
-install:
+install: ## Install the project and standalone developer tools
 	uv sync --all-extras --dev
+	uv tool install prek
+	uv tool install tox --with tox-uv
 
-lint: check-prek
+hooks: check-prek ## Install the prek git hooks
+	prek install -f
+
+lint: check-prek ## Run all prek hooks
 	prek run --all-files
 
-check: check-tools
-	tox run-parallel --parallel-no-spinner
-
-test: check-tools
+check: check-tools ## Run the full local CI-equivalent suite
 	tox run-parallel --parallel-no-spinner
 
 check-tools:
@@ -43,10 +49,4 @@ check-tools:
 check-prek:
 	@status=0; \
 	$(call check-command,prek,uv tool install prek); \
-	exit $$status
-
-check-tox:
-	@status=0; \
-	$(call check-command,tox,uv tool install tox --with tox-uv); \
-	$(call check-tox-runner); \
 	exit $$status

--- a/docs/home/CONTRIBUTING.md
+++ b/docs/home/CONTRIBUTING.md
@@ -4,13 +4,19 @@
 
 * The minimum supported version is Python 3.10. It is recommended to manage multiple Python versions on your system with [uv](https://docs.astral.sh/uv/)
 * Running the full local check suite also requires Node.js and npm for link validation
-* We maintain a Makefile with several commands to help with common tasks
+* Run `make` to see the available developer commands
 
 1. Install [uv](https://docs.astral.sh/uv/)
-2. Install the standalone developer tools with `uv tool install prek` and `uv tool install tox --with tox-uv`
-3. Run `uv sync` to create a virtual environment and install the dependencies
-4. Install [prek](https://prek.j178.dev/) hooks with `prek install -f`
-5. Run `make check` to verify that the local CI-equivalent checks pass
+2. Run `make install` to install the project and standalone developer tools
+3. Run `make hooks` to install the [prek](https://prek.j178.dev/) git hooks
+4. Run `make check` to verify that the local CI-equivalent checks pass
+
+`make install` uses uv to create the project environment with every development
+and optional dependency. It also installs prek and tox with the `tox-uv` plugin
+as standalone tools so repeated checks start quickly.
+
+Skip `make hooks` if you already manage hooks with Git's `core.hooksPath`
+setting. You can still run every hook manually with `make lint`.
 
 ## Code contributions
 
@@ -49,7 +55,8 @@ Each supported Python test environment runs ty before its tests.
 If `prek`, `tox`, or the `tox-uv` plugin is missing, the Makefile will stop
 early and print the matching `uv tool install ...` command to install it.
 
-`make test` runs the same full check suite.
+Use `make lint` to run only the prek hooks. For a focused test run, use
+`uv run pytest` followed by the test path and any pytest options.
 
 ### Running type checkers
 
@@ -70,7 +77,7 @@ We welcome contributions that improve the appearance and usability of the docs. 
 
 ### Running the docs locally
 
-After improving the docs, serve the documentation with `mkdocs serve`
+After improving the docs, serve the documentation with `uv run mkdocs serve`.
 
 ### Writing and editing docs
 


### PR DESCRIPTION
## Summary

- make the default `make` target show concise help for the supported developer commands
- make `make install` set up all project dependencies plus standalone `prek` and `tox`/`tox-uv` tools
- add an explicit `make hooks` target and document the `core.hooksPath` case
- align the contributor guide with the actual Makefile targets and uv-based focused commands
- record the developer-workflow improvement in the changelog

## Why

The contributor guide still described setup as a sequence of lower-level commands that did not match the existing `make install` target. In particular, the guide used plain `uv sync`, while the Makefile installs all extras, and tool/hook setup was spread across separate undocumented commands. This consolidates the supported workflow around discoverable Make targets without changing the established uv, prek, or tox execution model.

Closes #119.

## Validation

- `make help`
- `make install`
- `make lint`
- `make hooks` command verified in an isolated Git clone
- `tox run -e docs`
- `make check` (Python 3.10–3.14 ty and tests, tutorial tests, coverage, lint, docs, links, and package build)