### PR TITLE
Test schema generation from namespace packages

### DIFF
--- a/tests/_resources/namespace_package/schemas.py
+++ b/tests/_resources/namespace_package/schemas.py
@@ -1,0 +1,7 @@
+# ruff: noqa: INP001
+
+from pydantic import BaseModel, Field
+
+
+class NamespacePackageSchema(BaseModel):
+    value: str = Field(coerce_numbers_to_str=True)

--- a/tests/test_namespace_package.py
+++ b/tests/test_namespace_package.py
@@ -1,0 +1,54 @@
+from fastapi.testclient import TestClient
+
+import tests._resources.namespace_package as namespace_package
+from cadwyn import (
+    Cadwyn,
+    Version,
+    VersionBundle,
+    VersionChange,
+    VersionedAPIRouter,
+    generate_versioned_models,
+    schema,
+)
+from tests._resources.namespace_package.schemas import NamespacePackageSchema
+
+
+def test__namespace_package_models_work_in_schema_and_router_generation():
+    """Regression test for https://github.com/zmievsa/cadwyn/issues/160.
+
+    The issue predates runtime schema generation, when Cadwyn accepted a schemas package directly.
+    Models now reach VersionBundle through version change instructions.
+    """
+    assert namespace_package.__file__ is None
+
+    class MyVersionChange(VersionChange):
+        description = "Change value from an integer to a string"
+        instructions_to_migrate_to_previous_version = (
+            schema(NamespacePackageSchema).field("value").had(type=int),
+            schema(NamespacePackageSchema).field("value").didnt_have("coerce_numbers_to_str"),
+        )
+
+    versions = VersionBundle(Version("2001-01-01", MyVersionChange), Version("2000-01-01"))
+
+    versioned_models = generate_versioned_models(versions)
+    assert versioned_models["2000-01-01"][NamespacePackageSchema].model_validate({"value": 1}).model_dump() == {
+        "value": 1
+    }
+    assert versioned_models["2001-01-01"][NamespacePackageSchema].model_validate({"value": 1}).model_dump() == {
+        "value": "1"
+    }
+
+    router = VersionedAPIRouter()
+
+    @router.post("/test")
+    async def test_route(payload: NamespacePackageSchema) -> NamespacePackageSchema:
+        return payload
+
+    app = Cadwyn(versions=versions)
+    app.generate_and_include_versioned_routers(router)
+
+    client_2000 = TestClient(app, headers={app.router.api_version_parameter_name: "2000-01-01"})
+    client_2001 = TestClient(app, headers={app.router.api_version_parameter_name: "2001-01-01"})
+
+    assert client_2000.post("/test", json={"value": 1}).json() == {"value": 1}
+    assert client_2001.post("/test", json={"value": 1}).json() == {"value": "1"}


### PR DESCRIPTION
## Summary

- add a real PEP 420 namespace-package fixture with no `__init__.py`
- cover its model through the public `VersionBundle` and `generate_versioned_models()` workflow
- cover the same model through real versioned Cadwyn HTTP routing

Issue #160 predates runtime schema generation, when Cadwyn accepted a schemas package directly. The current runtime behavior already supports models defined in namespace packages, so this PR adds durable regression coverage without changing production code.

Closes #160

## Validation

- `uv run pytest -q tests/test_namespace_package.py`
- `uv run --python 3.10 --extra standard ty check --python-version 3.10`
- `uv run tox run-parallel --parallel-no-spinner -e coverage_erase,py3.14,py3.13,py3.12,py3.11,py3.10,tutorial,coverage_report`
- `uv run prek run --all-files`