### PR TITLE
Improve VersionChange example names

### DIFF
--- a/docs/concepts/changelogs.md
+++ b/docs/concepts/changelogs.md
@@ -10,7 +10,7 @@ Sometimes you might want to make private internal version changes or instruction
 from cadwyn import VersionChange, endpoint, hidden
 
 
-class VersionChangeWithOneHiddenInstruction(VersionChange):
+class RenameUserIdPathParameter(VersionChange):
     description = "..."
     instructions_to_migrate_to_previous_version = (
         hidden(endpoint("/users/{user_id}", ["GET"]).had(path="/users/{uid}")),
@@ -18,7 +18,7 @@ class VersionChangeWithOneHiddenInstruction(VersionChange):
 
 
 @hidden
-class CompletelyHiddenVersionChange(VersionChange):
+class RemoveAddressFromUser(VersionChange):
     description = "..."
     instructions_to_migrate_to_previous_version = (
         schema(User).field("address").existed_as(type=str),

--- a/docs/concepts/endpoint_migrations.md
+++ b/docs/concepts/endpoint_migrations.md
@@ -19,7 +19,7 @@ and then define it as existing in one of the older versions:
 from cadwyn import VersionChange, endpoint
 
 
-class MyChange(VersionChange):
+class RemoveGetUserByIdEndpoint(VersionChange):
     description = "..."
     instructions_to_migrate_to_previous_version = (
         endpoint("/users/{user_id}", ["GET"]).existed,
@@ -34,7 +34,7 @@ If you have an endpoint in a new version that should not exist in older versions
 from cadwyn import VersionChange, endpoint
 
 
-class MyChange(VersionChange):
+class AddGetCompanyByIdEndpoint(VersionChange):
     description = "..."
     instructions_to_migrate_to_previous_version = (
         endpoint("/companies/{company_id}", ["GET"]).didnt_exist,
@@ -49,7 +49,7 @@ If you want to change an endpoint attribute (like description) in a new version,
 from cadwyn import VersionChange, endpoint
 
 
-class MyChange(VersionChange):
+class ChangeGetUserByIdEndpointDescription(VersionChange):
     description = "..."
     instructions_to_migrate_to_previous_version = (
         endpoint("/users/{user_id}", ["GET"]).had(

--- a/docs/concepts/enum_migrations.md
+++ b/docs/concepts/enum_migrations.md
@@ -14,7 +14,7 @@ from enum import auto
 from cadwyn import VersionChange, enum
 
 
-class MyChange(VersionChange):
+class RemoveFooAndBarFromMyEnum(VersionChange):
     description = "..."
     instructions_to_migrate_to_previous_version = (
         enum(my_enum).had(foo="baz", bar=auto()),
@@ -27,7 +27,7 @@ class MyChange(VersionChange):
 from cadwyn import VersionChange, enum
 
 
-class MyChange(VersionChange):
+class AddFooAndBarToMyEnum(VersionChange):
     description = "..."
     instructions_to_migrate_to_previous_version = (
         enum(my_enum).didnt_have("foo", "bar"),

--- a/docs/concepts/schema_migrations.md
+++ b/docs/concepts/schema_migrations.md
@@ -11,7 +11,7 @@ from cadwyn import VersionChange, schema
 from pydantic import Field
 
 
-class MyChange(VersionChange):
+class RemoveFooFromMySchema(VersionChange):
     description = "..."
     instructions_to_migrate_to_previous_version = (
         schema(MySchema)
@@ -26,7 +26,7 @@ class MyChange(VersionChange):
 from cadwyn import VersionChange, schema
 
 
-class MyChange(VersionChange):
+class AddFooToMySchema(VersionChange):
     description = "..."
     instructions_to_migrate_to_previous_version = (
         schema(MySchema).field("foo").didnt_exist,
@@ -41,7 +41,7 @@ The following code sets an attribute of a field, such as a description:
 from cadwyn import VersionChange, schema
 
 
-class MyChange(VersionChange):
+class ChangeMySchemaFooDescription(VersionChange):
     description = "..."
     instructions_to_migrate_to_previous_version = (
         schema(MySchema).field("foo").had(description="Foo"),
@@ -54,7 +54,7 @@ The following code un-sets an attribute of a field, as if it never existed:
 from cadwyn import VersionChange, schema
 
 
-class MyChange(VersionChange):
+class AddDescriptionToMySchemaFoo(VersionChange):
     description = "..."
     instructions_to_migrate_to_previous_version = (
         schema(MySchema).field("foo").didnt_have("description"),
@@ -91,7 +91,7 @@ def validate_foo(cls, value):
     return value
 
 
-class MyChange(VersionChange):
+class RemoveFooValidatorFromMySchema(VersionChange):
     description = "..."
     instructions_to_migrate_to_previous_version = (
         schema(MySchema).validator(validate_foo).existed,
@@ -105,7 +105,7 @@ from cadwyn import VersionChange, schema
 from pydantic import Field, validator
 
 
-class MyChange(VersionChange):
+class AddFooValidatorToMySchema(VersionChange):
     description = "..."
     instructions_to_migrate_to_previous_version = (
         schema(MySchema).validator(MySchema.validate_foo).didnt_exist,
@@ -121,7 +121,7 @@ The following code replaces all schema name occurrences with a new one to ensure
 from cadwyn import VersionChange, schema
 
 
-class MyChange(VersionChange):
+class RenameOtherSchemaToMySchema(VersionChange):
     description = "..."
     instructions_to_migrate_to_previous_version = (
         schema(MySchema).had(name="OtherSchema"),

--- a/docs/concepts/version_changes.md
+++ b/docs/concepts/version_changes.md
@@ -150,7 +150,7 @@ from cadwyn import (
 from invoices import InvoiceCreateRequest
 
 
-class RemoveTaxIdEndpoints(VersionChange):
+class RenameInvoiceCreationDateToCreatedAt(VersionChange):
     description = "Rename 'Invoice.creation_date' to 'Invoice.created_at'."
     instructions_to_migrate_to_previous_version = (
         schema(InvoiceCreateRequest)
@@ -185,7 +185,7 @@ from invoices import (
 )
 
 
-class RemoveTaxIdEndpoints(VersionChange):
+class RenameInvoiceCreationDateToCreatedAt(VersionChange):
     description = "Rename 'Invoice.creation_date' to 'Invoice.created_at'."
     instructions_to_migrate_to_previous_version = (
         schema(BaseInvoice).field("creation_date").had(name="created_at"),
@@ -224,7 +224,7 @@ from cadwyn import (
 from invoices import BaseInvoice
 
 
-class RemoveTaxIdEndpoints(VersionChange):
+class RenameInvoiceCreationDateToCreatedAt(VersionChange):
     description = "Rename 'Invoice.creation_date' to 'Invoice.created_at'."
     instructions_to_migrate_to_previous_version = (
         schema(BaseInvoice).field("creation_date").had(name="created_at"),
@@ -255,7 +255,7 @@ from cadwyn import (
 )
 
 
-class RemoveTaxIdEndpoints(VersionChange):
+class ReplaceInvoiceNotFoundStatusCode400With404(VersionChange):
     description = "Replace status code 400 with 404 in 'GET /v1/invoices' if invoice is not found"
     instructions_to_migrate_to_previous_version = ()
 
@@ -305,7 +305,7 @@ from users import BaseUser
 
 
 # THIS IS AN EXAMPLE OF A POOR MIGRATION
-class RemoveTaxIdEndpoints(VersionChange):
+class ReplaceUserAddressesWithAddress(VersionChange):
     description = "Users now have 'address' field instead of 'addresses'"
     instructions_to_migrate_to_previous_version = (
         schema(BaseUser).field("address").didnt_exist,
@@ -345,7 +345,7 @@ from cadwyn import VersionChange, schema
 from users import User
 
 
-class RemoveTaxIdEndpoints(VersionChange):
+class ReplaceUserAddressesWithAddress(VersionChange):
     description = "Users now have 'address' field instead of 'addresses'"
     instructions_to_migrate_to_previous_version = (
         schema(User).field("address").didnt_exist,
@@ -454,7 +454,9 @@ As an example, let's use the tutorial section's case with the user and their add
 from cadwyn import VersionChangeWithSideEffects
 
 
-class UserAddressIsCheckedInExternalService(VersionChangeWithSideEffects):
+class RejectUserAddressesMissingFromExternalService(
+    VersionChangeWithSideEffects
+):
     description = (
         "User's address is now checked against existence in an external service. "
         "If it is not found, a 400 code is returned."
@@ -464,11 +466,11 @@ class UserAddressIsCheckedInExternalService(VersionChangeWithSideEffects):
 Then you will have the following check in your business logic:
 
 ```python
-from src.versions import versions, UserAddressIsCheckedInExternalService
+from src.versions import versions, RejectUserAddressesMissingFromExternalService
 
 
 async def create_user(payload):
-    if UserAddressIsCheckedInExternalService.is_applied:
+    if RejectUserAddressesMissingFromExternalService.is_applied:
         check_user_address_exists_in_an_external_service(payload.address)
     ...
 ```

--- a/docs/how_to/change_openapi_schemas/add_field.md
+++ b/docs/how_to/change_openapi_schemas/add_field.md
@@ -76,7 +76,7 @@ So we will make `phone` nullable in HEAD, then make it required in `latest`, and
     from users import UserCreateRequest
 
 
-    class MakePhoneNonNullableInLatest(VersionChange):
+    class MakeUserPhoneNonNullableInLatest(VersionChange):
         description = (
             "Make sure the phone is nullable in the HEAD version to support "
             "versions older than 2001_01_01 where it became non-nullable"
@@ -90,7 +90,7 @@ So we will make `phone` nullable in HEAD, then make it required in `latest`, and
 4. Add the following version change to `versions.v2001_01_01` (right under the version change above) which will make sure that `phone` is nullable in 2000_01_01:
 
     ```python
-    class AddPhoneToUser(VersionChange):
+    class AddRequiredPhoneToUser(VersionChange):
         description = (
             "Add a required phone field to User to allow us to do 2fa and to "
             "make it possible to verify new user accounts using an sms."
@@ -107,12 +107,15 @@ So we will make `phone` nullable in HEAD, then make it required in `latest`, and
     ```python
     from cadwyn import Version, VersionBundle, HeadVersion
     from datetime import date
-    from .v2001_01_01 import MakePhoneNonNullableInLatest, AddPhoneToUser
+    from .v2001_01_01 import (
+        MakeUserPhoneNonNullableInLatest,
+        AddRequiredPhoneToUser,
+    )
 
 
     version_bundle = VersionBundle(
-        HeadVersion(MakePhoneNonNullableInLatest),
-        Version("2001-01-01", AddPhoneToUser),
+        HeadVersion(MakeUserPhoneNonNullableInLatest),
+        Version("2001-01-01", AddRequiredPhoneToUser),
         Version("2000-01-01"),
     )
     ```

--- a/docs/how_to/change_openapi_schemas/change_field_type.md
+++ b/docs/how_to/change_openapi_schemas/change_field_type.md
@@ -79,7 +79,7 @@ Suppose that previously users could specify their date of birth as a datetime in
         return v
 
 
-    class ChangeDateOfBirthToDateInUserInLatest(VersionChange):
+    class ChangeUserDateOfBirthFromDatetimeToDateInLatest(VersionChange):
         description = (
             "Change 'BaseUser.date_of_birth' field type to datetime in HEAD "
             "to support versions and data before 2001-01-01. "
@@ -95,7 +95,7 @@ Suppose that previously users could specify their date of birth as a datetime in
 2. Add the following version change to `versions.v2001_01_01` (right under the version change above) which will make sure that `date_of_birth` is a datetime in 2000_01_01:
 
     ```python
-    class ChangeDateOfBirthToDateInUser(VersionChange):
+    class ChangeUserDateOfBirthFromDatetimeToDate(VersionChange):
         description = (
             "Change 'User.date_of_birth' field type to date instead of "
             "a datetime because storing the exact time is unnecessary."
@@ -112,8 +112,8 @@ Suppose that previously users could specify their date of birth as a datetime in
     from cadwyn import Version, VersionBundle, HeadVersion
 
     version_bundle = VersionBundle(
-        HeadVersion(ChangeDateOfBirthToDateInUserInLatest),
-        Version("2001-01-01", ChangeDateOfBirthToDateInUser),
+        HeadVersion(ChangeUserDateOfBirthFromDatetimeToDateInLatest),
+        Version("2001-01-01", ChangeUserDateOfBirthFromDatetimeToDate),
         Version("2000-01-01"),
     )
     ```

--- a/docs/how_to/change_openapi_schemas/changing_constraints.md
+++ b/docs/how_to/change_openapi_schemas/changing_constraints.md
@@ -11,7 +11,7 @@ Suppose you previously allowed users to have a name of arbitrary length but now 
     from users import UserCreateRequest
 
 
-    class AddLengthConstraintToNameInLatest(VersionChange):
+    class LimitUserNamesTo250CharactersInLatest(VersionChange):
         description = (
             "Remove the 'max_length' constraint from the HEAD version to "
             "support versions older than 2001_01_01 where the constraint "
@@ -25,7 +25,7 @@ Suppose you previously allowed users to have a name of arbitrary length but now 
 2. Then add the following migration under the migration above in the same file:
 
     ```python
-    class AddMaxLengthConstraintToUserNames(VersionChange):
+    class LimitUserNamesTo250Characters(VersionChange):
         description = (
             "Add a max length of 250 to user names when creating new "
             "users to prevent excessively large names from being used."
@@ -41,13 +41,13 @@ Suppose you previously allowed users to have a name of arbitrary length but now 
     from cadwyn import HeadVersion, Version, VersionBundle
 
     from .v2001_01_01 import (
-        AddLengthConstraintToNameInLatest,
-        AddMaxLengthConstraintToUserNames,
+        LimitUserNamesTo250CharactersInLatest,
+        LimitUserNamesTo250Characters,
     )
 
     version_bundle = VersionBundle(
-        HeadVersion(AddLengthConstraintToNameInLatest),
-        Version("2001-01-01", AddMaxLengthConstraintToUserNames),
+        HeadVersion(LimitUserNamesTo250CharactersInLatest),
+        Version("2001-01-01", LimitUserNamesTo250Characters),
         Version("2000-01-01"),
     )
     ```

--- a/docs/how_to/change_openapi_schemas/remove_field.md
+++ b/docs/how_to/change_openapi_schemas/remove_field.md
@@ -60,7 +60,7 @@ Let's say that we had a nullable `middle_name` field but we decided that it does
     from users import BaseUser
 
 
-    class RemoveMiddleNameFromLatestVersion(VersionChange):
+    class RemoveUserMiddleNameFromLatestVersion(VersionChange):
         description = (
             "Remove 'User.middle_name' from latest but keep it in HEAD "
             "to support versions before 2001-01-01."
@@ -99,7 +99,7 @@ Let's say that we had a nullable `middle_name` field but we decided that it does
     from .v2001_01_01 import RemoveZodiacSignFromUser
 
     version_bundle = VersionBundle(
-        HeadVersion(RemoveMiddleNameFromLatestVersion),
+        HeadVersion(RemoveUserMiddleNameFromLatestVersion),
         Version("2001-01-01", RemoveMiddleNameFromUser),
         Version("2000-01-01"),
     )

--- a/docs/how_to/change_openapi_schemas/rename_a_field_in_schema.md
+++ b/docs/how_to/change_openapi_schemas/rename_a_field_in_schema.md
@@ -17,7 +17,7 @@ Assume you had a `summary` field before but now you want to rename it to `bio`.
     from users import BaseUser, UserCreateRequest, UserResource
 
 
-    class RenameSummaryToBioInUser(VersionChange):
+    class RenameUserSummaryToBio(VersionChange):
         description = (
             "Rename 'summary' field to 'bio' to keep up with industry standards"
         )

--- a/docs_src/how_to/change_openapi_schemas/change_schema_without_endpoint/block001.py
+++ b/docs_src/how_to/change_openapi_schemas/change_schema_without_endpoint/block001.py
@@ -13,7 +13,7 @@ class User(BaseModel):
     id: str
 
 
-class ChangeUserIDToString(VersionChange):
+class ChangeUserIdFromIntegerToString(VersionChange):
     description = (
         "Change users' ID field to a string to support any kind of ID. "
         "Be careful: if you use a non-integer ID in a new version and "

--- a/docs_src/how_to/change_openapi_schemas/change_schema_without_endpoint/block002.py
+++ b/docs_src/how_to/change_openapi_schemas/change_schema_without_endpoint/block002.py
@@ -13,7 +13,7 @@ class User(BaseModel):
     id: str
 
 
-class ChangeUserIDToString(VersionChange):
+class ChangeUserIdFromIntegerToString(VersionChange):
     description = (
         "Change users' ID field to a string to support any kind of ID. "
         "Be careful: if you use a non-integer ID in a new version and "

--- a/docs_src/how_to/change_openapi_schemas/change_schema_without_endpoint/tests/test_block001.py
+++ b/docs_src/how_to/change_openapi_schemas/change_schema_without_endpoint/tests/test_block001.py
@@ -5,11 +5,12 @@ from cadwyn.exceptions import (
     RouteResponseBySchemaConverterDoesNotApplyToAnythingError,
 )
 from docs_src.how_to.change_openapi_schemas.change_schema_without_endpoint.block001 import (
-    ChangeUserIDToString,
+    ChangeUserIdFromIntegerToString,
 )
 
 versions = VersionBundle(
-    Version("2023-04-12", ChangeUserIDToString), Version("2022-11-16")
+    Version("2023-04-12", ChangeUserIdFromIntegerToString),
+    Version("2022-11-16"),
 )
 app = Cadwyn(versions=versions)
 

--- a/docs_src/how_to/change_openapi_schemas/change_schema_without_endpoint/tests/test_block002.py
+++ b/docs_src/how_to/change_openapi_schemas/change_schema_without_endpoint/tests/test_block002.py
@@ -2,11 +2,12 @@ from fastapi.testclient import TestClient
 
 from cadwyn import Cadwyn, Version, VersionBundle
 from docs_src.how_to.change_openapi_schemas.change_schema_without_endpoint.block002 import (
-    ChangeUserIDToString,
+    ChangeUserIdFromIntegerToString,
 )
 
 versions = VersionBundle(
-    Version("2023-04-12", ChangeUserIDToString), Version("2022-11-16")
+    Version("2023-04-12", ChangeUserIdFromIntegerToString),
+    Version("2022-11-16"),
 )
 app = Cadwyn(versions=versions)
 

--- a/docs_src/how_to/version_with_path_and_numbers_instead_of_headers_and_dates/block001.py
+++ b/docs_src/how_to/version_with_path_and_numbers_instead_of_headers_and_dates/block001.py
@@ -39,7 +39,7 @@ class UserAddressResourceList(BaseModel):
     data: list[UserAddressResource]
 
 
-class ChangeAddressToList(VersionChange):
+class ReplaceUserAddressWithListOfAddresses(VersionChange):
     description = "Change vat id to list"
     instructions_to_migrate_to_previous_version = (
         schema(BaseUser).field("addresses").didnt_exist,
@@ -56,7 +56,7 @@ class ChangeAddressToList(VersionChange):
         response.body["address"] = response.body["addresses"][0]
 
 
-class ChangeAddressesToSubresource(VersionChange):
+class MoveUserAddressesToSubresource(VersionChange):
     description = "Change vat ids to subresource"
     instructions_to_migrate_to_previous_version = (
         schema(BaseUser)
@@ -81,7 +81,7 @@ class ChangeAddressesToSubresource(VersionChange):
         ]
 
 
-class RemoveAddressesToCreateFromLatest(VersionChange):
+class RemoveAddressesToCreateFromLatestUserSchema(VersionChange):
     description = (
         "In order to support old versions, we gotta have `addresses_to_create` "
         "located in head schemas but we do not need this field in latest schemas."
@@ -92,9 +92,9 @@ class RemoveAddressesToCreateFromLatest(VersionChange):
 
 
 version_bundle = VersionBundle(
-    HeadVersion(RemoveAddressesToCreateFromLatest),
-    Version("v10", ChangeAddressesToSubresource),
-    Version("v9", ChangeAddressToList),
+    HeadVersion(RemoveAddressesToCreateFromLatestUserSchema),
+    Version("v10", MoveUserAddressesToSubresource),
+    Version("v9", ReplaceUserAddressWithListOfAddresses),
     Version("v8"),
 )
 

--- a/docs_src/quickstart/tutorial/block003.py
+++ b/docs_src/quickstart/tutorial/block003.py
@@ -41,7 +41,7 @@ async def get_user(user_id: uuid.UUID) -> UserResource:
     return database_parody[user_id]
 
 
-class ChangeAddressToList(VersionChange):
+class ReplaceUserAddressWithListOfAddresses(VersionChange):
     description = (
         "Give user the ability to have multiple addresses at the same time"
     )
@@ -63,7 +63,7 @@ class ChangeAddressToList(VersionChange):
 
 app = Cadwyn(
     versions=VersionBundle(
-        Version("2001-01-01", ChangeAddressToList),
+        Version("2001-01-01", ReplaceUserAddressWithListOfAddresses),
         Version("2000-01-01"),
     )
 )

--- a/tests/tutorial/main.py
+++ b/tests/tutorial/main.py
@@ -41,7 +41,7 @@ class UserAddressResourceList(BaseModel):
     data: list[UserAddressResource]
 
 
-class ChangeAddressToList(VersionChange):
+class ReplaceUserAddressWithListOfAddresses(VersionChange):
     description = "Change vat id to list"
     instructions_to_migrate_to_previous_version = (
         schema(BaseUser).field("addresses").didnt_exist,
@@ -58,7 +58,7 @@ class ChangeAddressToList(VersionChange):
         response.body["address"] = response.body["addresses"][0]
 
 
-class ChangeAddressesToSubresource(VersionChange):
+class MoveUserAddressesToSubresource(VersionChange):
     description = "Change vat ids to subresource"
     instructions_to_migrate_to_previous_version = (
         schema(BaseUser).field("addresses").existed_as(type=list[str], info=Field()),
@@ -77,7 +77,7 @@ class ChangeAddressesToSubresource(VersionChange):
         response.body["addresses"] = [id["value"] for id in response.body["_prefetched_addresses"]]
 
 
-class RemoveAddressesToCreateFromLatest(VersionChange):
+class RemoveAddressesToCreateFromLatestUserSchema(VersionChange):
     description = (
         "In order to support old versions, we gotta have `addresses_to_create` located in "
         "head schemas but we do not need this field in latest schemas."
@@ -86,9 +86,9 @@ class RemoveAddressesToCreateFromLatest(VersionChange):
 
 
 version_bundle = VersionBundle(
-    HeadVersion(RemoveAddressesToCreateFromLatest),
-    Version("2002-01-01", ChangeAddressesToSubresource),
-    Version("2001-01-01", ChangeAddressToList),
+    HeadVersion(RemoveAddressesToCreateFromLatestUserSchema),
+    Version("2002-01-01", MoveUserAddressesToSubresource),
+    Version("2001-01-01", ReplaceUserAddressWithListOfAddresses),
     Version("2000-01-01"),
 )
 


### PR DESCRIPTION
## Summary

- replace generic and copy-pasted `VersionChange` class names throughout reader-facing documentation
- make every documented example name action-led and specific to its breaking change
- keep executable docs sources, their tests, and the linked tutorial example consistent

## Validation

- `tox run-parallel --parallel-no-spinner -e py3.14,py3.13,py3.12,py3.11,py3.10,tutorial,docs,lint`
- `tox run -e lint`
- `tox run-parallel --parallel-no-spinner -e tutorial,docs`

Closes #110