### PR TITLE
Fix API version parameter required semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Please follow [the Keep a Changelog standard](https://keepachangelog.com/en/1.0.
 - Simplified contributor setup and development commands (#387)
 - Standardized test names around the `what`, `when`, and `expected` convention and documented test organization (#397)
 
+### Fixed
+
+- Mark the OpenAPI API version parameter as required unless the server has a configured default value (#277)
+
 ## [7.1.1]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Please follow [the Keep a Changelog standard](https://keepachangelog.com/en/1.0.
 
 ### Fixed
 
-- Mark the OpenAPI API version parameter as required unless the server has a configured default value (#277)
+- Mark each OpenAPI API version parameter as required unless omitting it can select that documented version (#277)
 
 ## [7.1.1]
 

--- a/cadwyn/applications.py
+++ b/cadwyn/applications.py
@@ -21,6 +21,7 @@ from fastapi.responses import HTMLResponse
 from fastapi.routing import _EffectiveRouteContext, _IncludedRouter, _iter_routes_with_context
 from fastapi.templating import Jinja2Templates
 from fastapi.utils import generate_unique_id
+from pydantic import TypeAdapter, ValidationError
 from starlette.middleware import Middleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
@@ -40,7 +41,7 @@ from cadwyn.middleware import (
     _generate_api_version_dependency,
 )
 from cadwyn.route_generation import copy_route, generate_versioned_routers
-from cadwyn.routing import _RootCadwynAPIRouter
+from cadwyn.routing import _get_closest_suitable_version, _RootCadwynAPIRouter
 from cadwyn.structure import VersionBundle
 
 if TYPE_CHECKING:
@@ -50,6 +51,7 @@ if TYPE_CHECKING:
 
 CURR_DIR = Path(__file__).resolve()
 logger = getLogger(__name__)
+_API_VERSION_DATE_ADAPTER = TypeAdapter(date)
 
 
 def _get_effective_include_in_schema(route: BaseRoute, effective_route_context: _EffectiveRouteContext | None) -> bool:
@@ -66,6 +68,30 @@ def _materialize_routes(routes: Sequence[BaseRoute]) -> list[BaseRoute]:
         copy_route(route, effective_route_context) if effective_route_context is not None else route
         for route, effective_route_context in _iter_routes_with_context(routes)
     ]
+
+
+def _get_api_version_parameter_metadata(
+    default_value: str,
+    *,
+    api_version_format: APIVersionFormat,
+    version_values: set[str],
+) -> tuple[bool, Union[str, None]]:
+    """Return whether the parameter is required and any default that OpenAPI can represent."""
+    if api_version_format == "date":
+        sorted_version_values = sorted(version_values)
+        routed_version = _get_closest_suitable_version(default_value, sorted_version_values)
+        if routed_version is None:
+            return True, None
+        try:
+            normalized_default_value = _API_VERSION_DATE_ADAPTER.validate_python(default_value).isoformat()
+        except ValidationError:
+            return False, None
+        if _get_closest_suitable_version(normalized_default_value, sorted_version_values) != routed_version:
+            return False, None
+        return False, normalized_default_value
+    if api_version_format == "string":
+        return (False, default_value) if default_value in version_values else (True, None)
+    assert_never(api_version_format)
 
 
 @dataclasses.dataclass(**DATACLASS_SLOTS)
@@ -244,6 +270,7 @@ class Cadwyn(FastAPI):
         self.api_version_pythonic_parameter_name = api_version_parameter_name.replace("-", "_")
         self.api_version_title = api_version_title
         self.api_version_description = api_version_description
+        self._api_version_default_value = api_version_default_value
         if api_version_location == "custom_header":
             self._api_version_manager = HeaderVersionManager(api_version_parameter_name=api_version_parameter_name)
             self._api_version_fastapi_depends_class = fastapi.Header
@@ -523,6 +550,18 @@ class Cadwyn(FastAPI):
         if version not in self.router.versioned_routers:  # pragma: no branch
             self.router.versioned_routers[version] = APIRouter(**self._kwargs_to_router)
 
+        if isinstance(self._api_version_default_value, str):
+            api_version_parameter_is_required, api_version_parameter_default_value = (
+                _get_api_version_parameter_metadata(
+                    self._api_version_default_value,
+                    api_version_format=self.api_version_format,
+                    version_values=set(self.router.versioned_routers),
+                )
+            )
+        else:
+            api_version_parameter_is_required = self._api_version_default_value is None
+            api_version_parameter_default_value = None
+
         versioned_router = self.router.versioned_routers[version]
         if self.openapi_url is not None:  # pragma: no branch
             versioned_router.add_route(
@@ -540,7 +579,9 @@ class Cadwyn(FastAPI):
                     Depends(
                         _generate_api_version_dependency(
                             api_version_pythonic_parameter_name=self.api_version_pythonic_parameter_name,
-                            default_value=version,
+                            version_example=version,
+                            api_version_is_required=api_version_parameter_is_required,
+                            api_version_default_value=api_version_parameter_default_value,
                             fastapi_depends_class=self._api_version_fastapi_depends_class,
                             validation_data_type=self.api_version_validation_data_type,
                             title=self.api_version_title,

--- a/cadwyn/applications.py
+++ b/cadwyn/applications.py
@@ -74,13 +74,14 @@ def _get_api_version_parameter_metadata(
     default_value: str,
     *,
     api_version_format: APIVersionFormat,
+    documented_version: str,
     version_values: set[str],
 ) -> tuple[bool, Union[str, None]]:
     """Return whether the parameter is required and any default that OpenAPI can represent."""
     if api_version_format == "date":
         sorted_version_values = sorted(version_values)
         routed_version = _get_closest_suitable_version(default_value, sorted_version_values)
-        if routed_version is None:
+        if routed_version != documented_version:
             return True, None
         try:
             normalized_default_value = _API_VERSION_DATE_ADAPTER.validate_python(default_value).isoformat()
@@ -90,7 +91,7 @@ def _get_api_version_parameter_metadata(
             return False, None
         return False, normalized_default_value
     if api_version_format == "string":
-        return (False, default_value) if default_value in version_values else (True, None)
+        return (False, default_value) if default_value == documented_version else (True, None)
     assert_never(api_version_format)
 
 
@@ -555,6 +556,7 @@ class Cadwyn(FastAPI):
                 _get_api_version_parameter_metadata(
                     self._api_version_default_value,
                     api_version_format=self.api_version_format,
+                    documented_version=version,
                     version_values=set(self.router.versioned_routers),
                 )
             )

--- a/cadwyn/middleware.py
+++ b/cadwyn/middleware.py
@@ -7,7 +7,6 @@ from collections.abc import Awaitable, Callable
 from contextvars import ContextVar
 from typing import Annotated, Any, Literal, Optional, Protocol, Union
 
-import fastapi
 from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware, DispatchFunction, RequestResponseEndpoint
 from starlette.types import ASGIApp
@@ -56,7 +55,9 @@ class URLVersionManager:
 def _generate_api_version_dependency(
     *,
     api_version_pythonic_parameter_name: str,
-    default_value: str,
+    version_example: str,
+    api_version_is_required: bool,
+    api_version_default_value: Union[str, None],
     fastapi_depends_class: Callable[..., Any],
     validation_data_type: Any,
     title: Optional[str] = None,
@@ -74,12 +75,12 @@ def _generate_api_version_dependency(
                 annotation=Annotated[
                     validation_data_type,
                     fastapi_depends_class(
-                        openapi_examples={"default": {"value": default_value}},
+                        openapi_examples={"default": {"value": version_example}},
                         title=title,
                         description=description,
                     ),
                 ],
-                default=default_value if fastapi_depends_class != fastapi.Path else inspect.Signature.empty,
+                default=inspect.Signature.empty if api_version_is_required else api_version_default_value,
             )
         ]
     )

--- a/cadwyn/routing.py
+++ b/cadwyn/routing.py
@@ -20,6 +20,11 @@ from cadwyn.structure.common import VersionType
 _logger = getLogger(__name__)
 
 
+def _get_closest_suitable_version(version: VersionType, versions: Sequence[VersionType]) -> Union[VersionType, None]:
+    index = bisect.bisect_right(versions, version)
+    return versions[index - 1] if index else None
+
+
 class _RootCadwynAPIRouter(APIRouter):
     def __init__(
         self,
@@ -54,14 +59,11 @@ class _RootCadwynAPIRouter(APIRouter):
         to some earlier version, making receivables behavior consistent even if API keeps getting new versions.
         """
         if self.api_version_format == "date":
-            index = bisect.bisect_left(self.versions, version)
+            picked_version = _get_closest_suitable_version(version, self.versions)
             # That's when we try to get a version earlier than the earliest possible version
-            if index == 0:
+            if picked_version is None:
                 return []
-            picked_version = self.versions[index - 1]
             self.api_version_var.set(picked_version)
-            # as bisect_left returns the index where to insert item x in list a, assuming a is sorted
-            # we need to get the previous item and that will be a match
             return self.versioned_routers[picked_version].routes
         return []  # pragma: no cover # This should not be possible
 

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -3,7 +3,7 @@ from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Annotated, cast
 
 import pytest
-from fastapi import APIRouter, BackgroundTasks, Depends, FastAPI, Response
+from fastapi import APIRouter, BackgroundTasks, Depends, FastAPI, Request, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.testclient import TestClient
 from pydantic import BaseModel
@@ -23,6 +23,9 @@ from tests._resources.versioned_app.app import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing import Literal
+
     from fastapi.routing import APIRoute
 
 
@@ -402,6 +405,181 @@ def test__get_openapi():
 
     resp = client_without_headers.get("/openapi.json?version=2021-01-01")
     assert resp.status_code == 200
+
+
+def test__get_openapi__version_header_without_server_default_is_required():
+    app = Cadwyn(versions=VersionBundle(Version("2023-04-14"), Version("2022-11-16")))
+    router = VersionedAPIRouter()
+
+    @router.get("/foo")
+    def foo():
+        raise NotImplementedError
+
+    app.generate_and_include_versioned_routers(router)
+
+    with TestClient(app) as client:
+        omitted_version_response = client.get("/foo")
+        schema_response = client.get("/openapi.json?version=2023-04-14")
+
+    parameter = schema_response.json()["paths"]["/foo"]["get"]["parameters"][0]
+    assert omitted_version_response.status_code == 404
+    assert parameter["name"] == "x-api-version"
+    assert parameter["required"] is True
+    assert "default" not in parameter["schema"]
+
+
+async def _get_default_api_version(_request: Request) -> str:
+    return "2022-11-16"
+
+
+@pytest.mark.parametrize(
+    ("default_value", "api_version_format", "versions", "expected_openapi_default"),
+    [
+        ("2022-11-16", "date", VersionBundle(Version("2023-04-14"), Version("2022-11-16")), "2022-11-16"),
+        (
+            "2023-04-14T00:00:00",
+            "date",
+            VersionBundle(Version("2023-04-14"), Version("2022-11-16")),
+            "2023-04-14",
+        ),
+        (
+            "20230414",
+            "date",
+            VersionBundle(Version("2023-04-14"), Version("2022-11-16")),
+            None,
+        ),
+        (
+            "2022278400",
+            "date",
+            VersionBundle(Version("2023-04-14"), Version("2022-11-16")),
+            None,
+        ),
+        (
+            _get_default_api_version,
+            "date",
+            VersionBundle(Version("2023-04-14"), Version("2022-11-16")),
+            None,
+        ),
+        ("v1", "string", VersionBundle(Version("v2"), Version("v1")), "v1"),
+    ],
+)
+def test__get_openapi__version_header_with_server_default_is_optional(
+    default_value: "str | Callable",
+    api_version_format: "Literal['date', 'string']",
+    versions: VersionBundle,
+    expected_openapi_default: "str | None",
+):
+    app = Cadwyn(
+        versions=versions,
+        api_version_default_value=default_value,
+        api_version_format=api_version_format,
+    )
+    router = VersionedAPIRouter()
+
+    @router.get("/foo")
+    def foo():
+        return None
+
+    app.generate_and_include_versioned_routers(router)
+
+    with TestClient(app) as client:
+        omitted_version_response = client.get("/foo")
+        schema_response = client.get(f"/openapi.json?version={versions.version_values[0]}")
+
+    parameter = schema_response.json()["paths"]["/foo"]["get"]["parameters"][0]
+    assert omitted_version_response.status_code == 200
+    assert parameter["name"] == "x-api-version"
+    assert parameter["required"] is False
+    if expected_openapi_default is None:
+        assert "default" not in parameter["schema"]
+    else:
+        assert parameter["schema"]["default"] == expected_openapi_default
+
+
+def test__get_openapi__default_matches_legacy_router_added_after_init__version_header_is_optional():
+    app = Cadwyn(
+        versions=VersionBundle(Version("2023-04-14")),
+        api_version_default_value="2022-11-16",
+    )
+    router = APIRouter()
+
+    @router.get("/foo")
+    def foo():
+        return None
+
+    with pytest.warns(DeprecationWarning):
+        app.add_header_versioned_routers(  # ty: ignore[deprecated]  # This test verifies the legacy API.
+            router,
+            header_value="2022-11-16",
+        )
+
+    with TestClient(app) as client:
+        omitted_version_response = client.get("/foo")
+        schema_response = client.get("/openapi.json?version=2022-11-16")
+
+    parameter = schema_response.json()["paths"]["/foo"]["get"]["parameters"][0]
+    assert omitted_version_response.status_code == 200
+    assert parameter["required"] is False
+    assert parameter["schema"]["default"] == "2022-11-16"
+
+
+@pytest.mark.parametrize(
+    ("default_value", "api_version_format", "versions"),
+    [
+        ("1681430400", "date", VersionBundle(Version("2023-04-14"), Version("2022-11-16"))),
+        ("2020-01-01", "date", VersionBundle(Version("2023-04-14"), Version("2022-11-16"))),
+        ("v0", "string", VersionBundle(Version("v2"), Version("v1"))),
+    ],
+)
+def test__get_openapi__unroutable_static_server_default_keeps_version_header_required(
+    default_value: str,
+    api_version_format: "Literal['date', 'string']",
+    versions: VersionBundle,
+):
+    app = Cadwyn(
+        versions=versions,
+        api_version_default_value=default_value,
+        api_version_format=api_version_format,
+    )
+    router = VersionedAPIRouter()
+
+    @router.get("/foo")
+    def foo():
+        raise NotImplementedError
+
+    app.generate_and_include_versioned_routers(router)
+
+    with TestClient(app) as client:
+        omitted_version_response = client.get("/foo")
+        schema_response = client.get(f"/openapi.json?version={versions.version_values[0]}")
+
+    parameter = schema_response.json()["paths"]["/foo"]["get"]["parameters"][0]
+    assert omitted_version_response.status_code == 404
+    assert parameter["required"] is True
+    assert "default" not in parameter["schema"]
+
+
+def test__get_openapi__path_version_parameter_is_required():
+    app = Cadwyn(
+        versions=VersionBundle(Version("2023-04-14"), Version("2022-11-16")),
+        api_version_location="path",
+        api_version_parameter_name="api_version",
+    )
+    router = VersionedAPIRouter()
+
+    @router.get("/{api_version}/foo")
+    def foo():
+        raise NotImplementedError
+
+    app.generate_and_include_versioned_routers(router)
+
+    with TestClient(app) as client:
+        schema_response = client.get("/openapi.json?version=2023-04-14")
+
+    parameter = schema_response.json()["paths"]["/{api_version}/foo"]["get"]["parameters"][0]
+    assert parameter["name"] == "api_version"
+    assert parameter["required"] is True
+    assert "default" not in parameter["schema"]
 
 
 def test__get_openapi__nonexisting_version__should_return_404():

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -433,40 +433,51 @@ async def _get_default_api_version(_request: Request) -> str:
 
 
 @pytest.mark.parametrize(
-    ("default_value", "api_version_format", "versions", "expected_openapi_default"),
+    ("default_value", "api_version_format", "versions", "documented_version", "expected_openapi_default"),
     [
-        ("2022-11-16", "date", VersionBundle(Version("2023-04-14"), Version("2022-11-16")), "2022-11-16"),
+        (
+            "2022-11-16",
+            "date",
+            VersionBundle(Version("2023-04-14"), Version("2022-11-16")),
+            "2022-11-16",
+            "2022-11-16",
+        ),
         (
             "2023-04-14T00:00:00",
             "date",
             VersionBundle(Version("2023-04-14"), Version("2022-11-16")),
+            "2023-04-14",
             "2023-04-14",
         ),
         (
             "20230414",
             "date",
             VersionBundle(Version("2023-04-14"), Version("2022-11-16")),
+            "2023-04-14",
             None,
         ),
         (
             "2022278400",
             "date",
             VersionBundle(Version("2023-04-14"), Version("2022-11-16")),
+            "2022-11-16",
             None,
         ),
         (
             _get_default_api_version,
             "date",
             VersionBundle(Version("2023-04-14"), Version("2022-11-16")),
+            "2022-11-16",
             None,
         ),
-        ("v1", "string", VersionBundle(Version("v2"), Version("v1")), "v1"),
+        ("v1", "string", VersionBundle(Version("v2"), Version("v1")), "v1", "v1"),
     ],
 )
 def test__get_openapi__version_header_with_server_default_is_optional(
     default_value: "str | Callable",
     api_version_format: "Literal['date', 'string']",
     versions: VersionBundle,
+    documented_version: str,
     expected_openapi_default: "str | None",
 ):
     app = Cadwyn(
@@ -484,7 +495,7 @@ def test__get_openapi__version_header_with_server_default_is_optional(
 
     with TestClient(app) as client:
         omitted_version_response = client.get("/foo")
-        schema_response = client.get(f"/openapi.json?version={versions.version_values[0]}")
+        schema_response = client.get(f"/openapi.json?version={documented_version}")
 
     parameter = schema_response.json()["paths"]["/foo"]["get"]["parameters"][0]
     assert omitted_version_response.status_code == 200
@@ -494,6 +505,62 @@ def test__get_openapi__version_header_with_server_default_is_optional(
         assert "default" not in parameter["schema"]
     else:
         assert parameter["schema"]["default"] == expected_openapi_default
+
+
+@pytest.mark.parametrize(
+    "router_registration_order",
+    [
+        ("2023-04-14", "2022-11-16"),
+        ("2022-11-16", "2023-04-14"),
+    ],
+)
+def test__get_openapi__static_default_only_makes_its_routed_version_optional(
+    router_registration_order: tuple[str, str],
+):
+    app = Cadwyn(
+        versions=VersionBundle(Version("2023-04-14"), Version("2022-11-16")),
+        api_version_default_value="2022-11-16",
+    )
+    newer_router = APIRouter()
+    older_router = APIRouter()
+
+    @newer_router.get("/new-only")
+    def new_only():
+        return {"version": "2023-04-14"}
+
+    @older_router.get("/old-only")
+    def old_only():
+        return {"version": "2022-11-16"}
+
+    routers = {
+        "2023-04-14": newer_router,
+        "2022-11-16": older_router,
+    }
+    with pytest.warns(DeprecationWarning):
+        for version in router_registration_order:
+            app.add_header_versioned_routers(  # ty: ignore[deprecated]  # This test verifies the legacy API.
+                routers[version],
+                header_value=version,
+            )
+
+    with TestClient(app) as client:
+        omitted_newer_response = client.get("/new-only")
+        explicit_newer_response = client.get("/new-only", headers={"x-api-version": "2023-04-14"})
+        omitted_older_response = client.get("/old-only")
+        newer_schema_response = client.get("/openapi.json?version=2023-04-14")
+        older_schema_response = client.get("/openapi.json?version=2022-11-16")
+
+    assert omitted_newer_response.status_code == 404
+    assert explicit_newer_response.status_code == 200
+    assert omitted_older_response.status_code == 200
+
+    newer_parameter = newer_schema_response.json()["paths"]["/new-only"]["get"]["parameters"][0]
+    assert newer_parameter["required"] is True
+    assert "default" not in newer_parameter["schema"]
+
+    older_parameter = older_schema_response.json()["paths"]["/old-only"]["get"]["parameters"][0]
+    assert older_parameter["required"] is False
+    assert older_parameter["schema"]["default"] == "2022-11-16"
 
 
 def test__get_openapi__default_matches_legacy_router_added_after_init__version_header_is_optional():


### PR DESCRIPTION
## Summary

- mark the OpenAPI API-version parameter as required when omitted versions are rejected
- keep the parameter optional when `api_version_default_value` supplies a routable static value or async default
- keep unroutable static defaults required and normalize documented date defaults to OpenAPI's date format
- preserve required path-version parameters and distinguish route-version examples from real server defaults

## Root cause

Cadwyn used each generated route's version example as the FastAPI dependency's Python default. FastAPI therefore emitted `required: false` even when Cadwyn's middleware had no server-side default and routing rejected an omitted version.

This fixes the dependency signature that FastAPI uses to derive OpenAPI instead of post-processing the generated schema. Static defaults are checked against Cadwyn's date-waterfalling or exact-string routing rules before they make the parameter optional.

## Validation

- public OpenAPI and request behavior regressions for required headers, valid and invalid static defaults, async defaults, string versions, and path parameters
- full tox suite across Python 3.10, 3.11, 3.12, 3.13, and 3.14, including per-version `ty` checks
- 100% coverage, tutorial, lint, docs, links, and package build checks

Closes #277
