### PR TITLE
Support ResponseInfo media type and background migrations

### DIFF
--- a/cadwyn/route_generation.py
+++ b/cadwyn/route_generation.py
@@ -29,7 +29,7 @@ from cadwyn.exceptions import (
     RouterPathParamsModifiedError,
 )
 from cadwyn.schema_generation import (
-    _add_data_migration_params,
+    _add_request_and_response_params,
     generate_versioned_models,
 )
 from cadwyn.structure import Version, VersionBundle
@@ -233,7 +233,7 @@ class _EndpointTransformer(Generic[_R, _WR]):
         for route_index, head_route in enumerate(self.head_router.routes):
             if not isinstance(head_route, APIRoute):
                 continue
-            _add_data_migration_params(head_route)
+            _add_request_and_response_params(head_route)
             copy_of_dependant = copy(head_route.dependant)
 
             for older_router in list(routers.values()):
@@ -530,14 +530,9 @@ def _add_data_migrations_to_route(
     dependant_for_request_migrations: "Dependant",
     versions: VersionBundle,
 ):
-    if not (  # pragma: no cover
-        route.dependant.request_param_name
-        and route.dependant.response_param_name
-        and route.dependant.background_tasks_param_name
-    ):
+    if not (route.dependant.request_param_name and route.dependant.response_param_name):  # pragma: no cover
         raise CadwynError(
-            f"{route.dependant.request_param_name=}, {route.dependant.response_param_name=}, "
-            f"{route.dependant.background_tasks_param_name=} "
+            f"{route.dependant.request_param_name=}, {route.dependant.response_param_name=} "
             f"for route {list(_route_methods(route))} {route.path} which should not be possible. "
             "Please, contact my author.",
         )

--- a/cadwyn/route_generation.py
+++ b/cadwyn/route_generation.py
@@ -29,7 +29,7 @@ from cadwyn.exceptions import (
     RouterPathParamsModifiedError,
 )
 from cadwyn.schema_generation import (
-    _add_request_and_response_params,
+    _add_data_migration_params,
     generate_versioned_models,
 )
 from cadwyn.structure import Version, VersionBundle
@@ -233,7 +233,7 @@ class _EndpointTransformer(Generic[_R, _WR]):
         for route_index, head_route in enumerate(self.head_router.routes):
             if not isinstance(head_route, APIRoute):
                 continue
-            _add_request_and_response_params(head_route)
+            _add_data_migration_params(head_route)
             copy_of_dependant = copy(head_route.dependant)
 
             for older_router in list(routers.values()):

--- a/cadwyn/route_generation.py
+++ b/cadwyn/route_generation.py
@@ -530,9 +530,14 @@ def _add_data_migrations_to_route(
     dependant_for_request_migrations: "Dependant",
     versions: VersionBundle,
 ):
-    if not (route.dependant.request_param_name and route.dependant.response_param_name):  # pragma: no cover
+    if not (  # pragma: no cover
+        route.dependant.request_param_name
+        and route.dependant.response_param_name
+        and route.dependant.background_tasks_param_name
+    ):
         raise CadwynError(
-            f"{route.dependant.request_param_name=}, {route.dependant.response_param_name=} "
+            f"{route.dependant.request_param_name=}, {route.dependant.response_param_name=}, "
+            f"{route.dependant.background_tasks_param_name=} "
             f"for route {list(_route_methods(route))} {route.path} which should not be possible. "
             "Please, contact my author.",
         )

--- a/cadwyn/schema_generation.py
+++ b/cadwyn/schema_generation.py
@@ -779,7 +779,11 @@ def _add_data_migration_params(route: APIRoute):
     if not route.dependant.response_param_name:
         route.dependant.response_param_name = _CADWYN_RESPONSE_PARAM_NAME
     if not route.dependant.background_tasks_param_name:
-        route.dependant.background_tasks_param_name = _CADWYN_BACKGROUND_TASKS_PARAM_NAME
+        parameter_names = inspect.signature(route.endpoint).parameters
+        background_tasks_param_name = _CADWYN_BACKGROUND_TASKS_PARAM_NAME
+        while background_tasks_param_name in parameter_names:
+            background_tasks_param_name = f"_{background_tasks_param_name}"
+        route.dependant.background_tasks_param_name = background_tasks_param_name
 
 
 @final

--- a/cadwyn/schema_generation.py
+++ b/cadwyn/schema_generation.py
@@ -28,6 +28,7 @@ import fastapi.utils
 import pydantic
 import pydantic._internal._decorators
 from fastapi import Response
+from fastapi.dependencies.models import Dependant
 from fastapi.routing import APIRoute
 from pydantic import BaseModel, Field, RootModel
 from pydantic._internal import _decorators
@@ -646,7 +647,7 @@ class _AnnotationTransformer:
         )
         route.dependant = route_copy.dependant
         route.body_field = route_copy.body_field
-        _add_data_migration_params(route)
+        _add_request_and_response_params(route)
 
     @classmethod
     def _modify_callable_annotations(  # pragma: no branch # because of lambdas
@@ -773,12 +774,20 @@ def is_coroutine_callable(call: Callable[..., object]) -> bool:  # pragma: no co
     return iscoroutinefunction(dunder_call)
 
 
-def _add_data_migration_params(route: APIRoute):
+def _dependant_uses_background_tasks(dependant: Dependant) -> bool:
+    return dependant.background_tasks_param_name is not None or any(
+        _dependant_uses_background_tasks(dependency) for dependency in dependant.dependencies
+    )
+
+
+def _add_request_and_response_params(route: APIRoute):
     if not route.dependant.request_param_name:
         route.dependant.request_param_name = _CADWYN_REQUEST_PARAM_NAME
     if not route.dependant.response_param_name:
         route.dependant.response_param_name = _CADWYN_RESPONSE_PARAM_NAME
-    if not route.dependant.background_tasks_param_name:
+    if not route.dependant.background_tasks_param_name and any(
+        _dependant_uses_background_tasks(dependency) for dependency in route.dependant.dependencies
+    ):
         parameter_names = inspect.signature(route.endpoint).parameters
         background_tasks_param_name = _CADWYN_BACKGROUND_TASKS_PARAM_NAME
         while background_tasks_param_name in parameter_names:

--- a/cadwyn/schema_generation.py
+++ b/cadwyn/schema_generation.py
@@ -79,7 +79,12 @@ from cadwyn.structure.schemas import (
     ValidatorExistedInstruction,
     _get_model_decorators,
 )
-from cadwyn.structure.versions import _CADWYN_REQUEST_PARAM_NAME, _CADWYN_RESPONSE_PARAM_NAME, VersionBundle
+from cadwyn.structure.versions import (
+    _CADWYN_BACKGROUND_TASKS_PARAM_NAME,
+    _CADWYN_REQUEST_PARAM_NAME,
+    _CADWYN_RESPONSE_PARAM_NAME,
+    VersionBundle,
+)
 
 from ._utils import iscoroutinefunction
 
@@ -641,7 +646,7 @@ class _AnnotationTransformer:
         )
         route.dependant = route_copy.dependant
         route.body_field = route_copy.body_field
-        _add_request_and_response_params(route)
+        _add_data_migration_params(route)
 
     @classmethod
     def _modify_callable_annotations(  # pragma: no branch # because of lambdas
@@ -768,11 +773,13 @@ def is_coroutine_callable(call: Callable[..., object]) -> bool:  # pragma: no co
     return iscoroutinefunction(dunder_call)
 
 
-def _add_request_and_response_params(route: APIRoute):
+def _add_data_migration_params(route: APIRoute):
     if not route.dependant.request_param_name:
         route.dependant.request_param_name = _CADWYN_REQUEST_PARAM_NAME
     if not route.dependant.response_param_name:
         route.dependant.response_param_name = _CADWYN_RESPONSE_PARAM_NAME
+    if not route.dependant.background_tasks_param_name:
+        route.dependant.background_tasks_param_name = _CADWYN_BACKGROUND_TASKS_PARAM_NAME
 
 
 @final

--- a/cadwyn/structure/data.py
+++ b/cadwyn/structure/data.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass, field
 from typing import ClassVar, Union, cast
 
 from fastapi import Request, Response
-from starlette.background import BackgroundTask, BackgroundTasks
 from starlette.datastructures import FormData, MutableHeaders, UploadFile
 from typing_extensions import Any, overload
 
@@ -42,25 +41,25 @@ class RequestInfo:
 
 
 class ResponseInfo:
-    __slots__ = ("_background", "_background_tasks", "_response", "body")
+    __slots__ = ("_media_type_resolver", "_media_type_was_set", "_response", "body")
 
     def __init__(
         self,
         response: Response,
         body: Any,
         *,
-        _background_tasks: Union[BackgroundTasks, None] = None,
+        _media_type_resolver: Union[Callable[[object], tuple[Union[str, None], str]], None] = None,
     ):
         super().__init__()
         self.body = body
         self._response = response
-        self._background_tasks = _background_tasks
-        if response.background is not None:
-            self._background: Union[BackgroundTask, None] = response.background
-        elif _background_tasks is not None and _background_tasks.tasks:
-            self._background = _background_tasks
-        else:
-            self._background = None
+        self._media_type_resolver = _media_type_resolver
+        self._media_type_was_set = False
+
+    def _resolve_media_type(self) -> None:
+        if self._media_type_resolver is not None:
+            self._response.media_type, self._response.charset = self._media_type_resolver(self.body)
+            self._media_type_resolver = None
 
     @property
     def status_code(self) -> int:
@@ -76,30 +75,20 @@ class ResponseInfo:
 
     @property
     def media_type(self) -> Union[str, None]:
+        self._resolve_media_type()
         return self._response.media_type
 
     @media_type.setter
     def media_type(self, value: Union[str, None]) -> None:
+        self._resolve_media_type()
         self._response.media_type = value
-
-    @property
-    def background(self) -> Union[BackgroundTask, None]:
-        if self._background_tasks is None:
-            return self._response.background
-        return self._background
-
-    @background.setter
-    def background(self, value: Union[BackgroundTask, None]) -> None:
-        if self._background_tasks is None:
-            self._response.background = value
-        else:
-            self._background = value
-            if value is None:
-                self._background_tasks.tasks = []
-            elif isinstance(value, BackgroundTasks):
-                self._background_tasks.tasks = value.tasks
-            else:
-                self._background_tasks.tasks = [value]
+        self._media_type_was_set = True
+        if "content-type" in self._response.headers:
+            del self._response.headers["content-type"]
+        if value is not None:
+            if value.startswith("text/") and "charset=" not in value.lower():
+                value += "; charset=" + self._response.charset
+            self._response.headers["content-type"] = value
 
     @same_method_definition_as_in(Response.set_cookie)
     def set_cookie(self, *args: Any, **kwargs: Any) -> None:

--- a/cadwyn/structure/data.py
+++ b/cadwyn/structure/data.py
@@ -55,9 +55,12 @@ class ResponseInfo:
         self.body = body
         self._response = response
         self._background_tasks = _background_tasks
-        self._background: Union[BackgroundTask, None] = (
-            _background_tasks if _background_tasks is not None and _background_tasks.tasks else None
-        )
+        if response.background is not None:
+            self._background: Union[BackgroundTask, None] = response.background
+        elif _background_tasks is not None and _background_tasks.tasks:
+            self._background = _background_tasks
+        else:
+            self._background = None
 
     @property
     def status_code(self) -> int:

--- a/cadwyn/structure/data.py
+++ b/cadwyn/structure/data.py
@@ -92,11 +92,11 @@ class ResponseInfo:
         else:
             self._background = value
             if value is None:
-                self._background_tasks.tasks.clear()
+                self._background_tasks.tasks = []
             elif isinstance(value, BackgroundTasks):
-                self._background_tasks.tasks[:] = value.tasks
+                self._background_tasks.tasks = value.tasks
             else:
-                self._background_tasks.tasks[:] = [value]
+                self._background_tasks.tasks = [value]
 
     @same_method_definition_as_in(Response.set_cookie)
     def set_cookie(self, *args: Any, **kwargs: Any) -> None:

--- a/cadwyn/structure/data.py
+++ b/cadwyn/structure/data.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from typing import ClassVar, Union, cast
 
 from fastapi import Request, Response
+from starlette.background import BackgroundTask
 from starlette.datastructures import FormData, MutableHeaders, UploadFile
 from typing_extensions import Any, overload
 
@@ -40,7 +41,6 @@ class RequestInfo:
         return self._form
 
 
-# TODO (https://github.com/zmievsa/cadwyn/issues/111): handle _response.media_type and _response.background
 class ResponseInfo:
     __slots__ = ("_response", "body")
 
@@ -60,6 +60,28 @@ class ResponseInfo:
     @property
     def headers(self) -> MutableHeaders:
         return self._response.headers
+
+    @property
+    def media_type(self) -> Union[str, None]:
+        return self._response.media_type
+
+    @media_type.setter
+    def media_type(self, value: Union[str, None]) -> None:
+        self._response.media_type = value
+        if value is None:
+            del self.headers["content-type"]
+        elif value.startswith("text/") and "charset=" not in value.lower():
+            self.headers["content-type"] = f"{value}; charset={self._response.charset}"
+        else:
+            self.headers["content-type"] = value
+
+    @property
+    def background(self) -> Union[BackgroundTask, None]:
+        return self._response.background
+
+    @background.setter
+    def background(self, value: Union[BackgroundTask, None]) -> None:
+        self._response.background = value
 
     @same_method_definition_as_in(Response.set_cookie)
     def set_cookie(self, *args: Any, **kwargs: Any) -> None:

--- a/cadwyn/structure/data.py
+++ b/cadwyn/structure/data.py
@@ -68,12 +68,6 @@ class ResponseInfo:
     @media_type.setter
     def media_type(self, value: Union[str, None]) -> None:
         self._response.media_type = value
-        if value is None:
-            del self.headers["content-type"]
-        elif value.startswith("text/") and "charset=" not in value.lower():
-            self.headers["content-type"] = f"{value}; charset={self._response.charset}"
-        else:
-            self.headers["content-type"] = value
 
     @property
     def background(self) -> Union[BackgroundTask, None]:

--- a/cadwyn/structure/data.py
+++ b/cadwyn/structure/data.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 from typing import ClassVar, Union, cast
 
 from fastapi import Request, Response
-from starlette.background import BackgroundTask
+from starlette.background import BackgroundTask, BackgroundTasks
 from starlette.datastructures import FormData, MutableHeaders, UploadFile
 from typing_extensions import Any, overload
 
@@ -42,12 +42,22 @@ class RequestInfo:
 
 
 class ResponseInfo:
-    __slots__ = ("_response", "body")
+    __slots__ = ("_background", "_background_tasks", "_response", "body")
 
-    def __init__(self, response: Response, body: Any):
+    def __init__(
+        self,
+        response: Response,
+        body: Any,
+        *,
+        _background_tasks: Union[BackgroundTasks, None] = None,
+    ):
         super().__init__()
         self.body = body
         self._response = response
+        self._background_tasks = _background_tasks
+        self._background: Union[BackgroundTask, None] = (
+            _background_tasks if _background_tasks is not None and _background_tasks.tasks else None
+        )
 
     @property
     def status_code(self) -> int:
@@ -71,11 +81,22 @@ class ResponseInfo:
 
     @property
     def background(self) -> Union[BackgroundTask, None]:
-        return self._response.background
+        if self._background_tasks is None:
+            return self._response.background
+        return self._background
 
     @background.setter
     def background(self, value: Union[BackgroundTask, None]) -> None:
-        self._response.background = value
+        if self._background_tasks is None:
+            self._response.background = value
+        else:
+            self._background = value
+            if value is None:
+                self._background_tasks.tasks.clear()
+            elif isinstance(value, BackgroundTasks):
+                self._background_tasks.tasks[:] = value.tasks
+            else:
+                self._background_tasks.tasks[:] = [value]
 
     @same_method_definition_as_in(Response.set_cookie)
     def set_cookie(self, *args: Any, **kwargs: Any) -> None:

--- a/cadwyn/structure/versions.py
+++ b/cadwyn/structure/versions.py
@@ -428,7 +428,7 @@ class VersionBundle:
         *,
         exit_stack: AsyncExitStack,
         embed_body_fields: bool,
-        background_tasks: Union[BackgroundTasks, None],
+        background_tasks: BackgroundTasks,
     ) -> dict[str, Any]:
         start = self.reversed_version_values.index(current_version)
         head_route_id = id(head_route)
@@ -452,6 +452,9 @@ class VersionBundle:
             body_for_solving = request_info.body
 
         # Remember this: if len(body_params) == 1, then route.body_schema == route.dependant.body_params[0]
+        # FastAPI has already resolved these dependencies with the same holder. Preserve its tasks so this second
+        # resolution can validate the migrated request without scheduling dependency background tasks twice.
+        background_tasks_before_resolving_head_dependencies = list(background_tasks.tasks)
         result = await solve_dependencies(
             request=request,
             response=response,
@@ -462,6 +465,7 @@ class VersionBundle:
             embed_body_fields=embed_body_fields,
             background_tasks=background_tasks,
         )
+        background_tasks.tasks[:] = background_tasks_before_resolving_head_dependencies
         if result.errors:
             raise CadwynHeadRequestValidationError(result.errors, body=request_info.body, version=current_version)
         return result.values
@@ -502,7 +506,7 @@ class VersionBundle:
         dependant_for_request_migrations: Dependant,
         *,
         request_param_name: str,
-        background_tasks_param_name: Union[str, None],
+        background_tasks_param_name: str,
         response_param_name: str,
     ) -> "Callable[[Endpoint[_P, _R]], Callable[..., Coroutine[Any, Any, _R]]]":
         def wrapper(endpoint: "Endpoint[_P, _R]") -> "Callable[..., Coroutine[Any, Any, _R]]":
@@ -510,9 +514,7 @@ class VersionBundle:
             async def decorator(*args: Any, **kwargs: Any) -> _R:
                 request_param: FastapiRequest = kwargs[request_param_name]
                 response_param: FastapiResponse = kwargs[response_param_name]
-                background_tasks: Union[BackgroundTasks, None] = (
-                    kwargs.get(background_tasks_param_name) if background_tasks_param_name is not None else None
-                )
+                background_tasks: BackgroundTasks = kwargs[background_tasks_param_name]
                 method = request_param.method
                 response = Sentinel
                 async with AsyncExitStack() as exit_stack:
@@ -575,7 +577,7 @@ class VersionBundle:
         kwargs: dict[str, Any],
         fastapi_response_dependency: FastapiResponse,
         *,
-        background_tasks: Union[BackgroundTasks, None],
+        background_tasks: BackgroundTasks,
     ) -> Any:
         raised_exception = None
         if response_param_name == _CADWYN_RESPONSE_PARAM_NAME:
@@ -709,7 +711,7 @@ class VersionBundle:
         *,
         exit_stack: AsyncExitStack,
         embed_body_fields: bool,
-        background_tasks: Union[BackgroundTasks, None],
+        background_tasks: BackgroundTasks,
     ) -> dict[str, Any]:
         request: FastapiRequest = kwargs[request_param_name]
         if request_param_name == _CADWYN_REQUEST_PARAM_NAME:

--- a/cadwyn/structure/versions.py
+++ b/cadwyn/structure/versions.py
@@ -16,11 +16,14 @@ from fastapi import Request as FastapiRequest
 from fastapi import Response as FastapiResponse
 from fastapi._compat import ModelField
 from fastapi.concurrency import run_in_threadpool
+from fastapi.datastructures import DefaultPlaceholder
 from fastapi.dependencies.models import Dependant
 from fastapi.dependencies.utils import solve_dependencies
-from fastapi.exceptions import RequestValidationError
+from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import RequestValidationError, ResponseValidationError
 from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
-from fastapi.routing import APIRoute
+from fastapi.routing import APIRoute, serialize_response
+from fastapi.utils import is_body_allowed_for_status_code
 from pydantic import BaseModel
 from pydantic_core import PydanticUndefined
 from starlette._utils import is_async_callable
@@ -111,6 +114,83 @@ def _prepare_response_content(
             for k, v in res.items()
         }
     return res
+
+
+def _get_actual_response_class(route: APIRoute) -> type[FastapiResponse]:
+    if isinstance(route.response_class, DefaultPlaceholder):
+        return route.response_class.value
+    return route.response_class
+
+
+def _serialize_response_for_metadata(route: APIRoute, response_body: object) -> object:
+    if route.response_field is None:
+        return jsonable_encoder(response_body)
+
+    value, errors = route.response_field.validate(response_body, {}, loc=("response",))
+    if errors:
+        raise ResponseValidationError(errors=errors, body=response_body)
+    return route.response_field.serialize(
+        value,
+        include=route.response_model_include,
+        exclude=route.response_model_exclude,
+        by_alias=route.response_model_by_alias,
+        exclude_unset=route.response_model_exclude_unset,
+        exclude_defaults=route.response_model_exclude_defaults,
+        exclude_none=route.response_model_exclude_none,
+    )
+
+
+def _get_response_metadata(
+    route: APIRoute,
+    status_code: int,
+    background_tasks: Union[BackgroundTasks, None],
+    response_body: object,
+) -> tuple[Union[str, None], str]:
+    probe_background_tasks = None
+    if background_tasks is not None:
+        probe_background_tasks = BackgroundTasks()
+        probe_background_tasks.tasks.extend(background_tasks.tasks)
+    response = _get_actual_response_class(route)(
+        _serialize_response_for_metadata(route, response_body),
+        status_code=status_code,
+        background=probe_background_tasks,
+    )
+    return response.media_type, response.charset
+
+
+async def _materialize_response(
+    response_info: ResponseInfo,
+    route: APIRoute,
+    background_tasks: Union[BackgroundTasks, None],
+) -> FastapiResponse:
+    use_dump_json = route.response_field is not None and isinstance(route.response_class, DefaultPlaceholder)
+    content = await serialize_response(
+        field=route.response_field,
+        response_content=response_info.body,
+        include=route.response_model_include,
+        exclude=route.response_model_exclude,
+        by_alias=route.response_model_by_alias,
+        exclude_unset=route.response_model_exclude_unset,
+        exclude_defaults=route.response_model_exclude_defaults,
+        exclude_none=route.response_model_exclude_none,
+        is_coroutine=True,
+        dump_json=use_dump_json,
+    )
+    if use_dump_json:
+        response = FastapiResponse(content=content, status_code=response_info.status_code)
+    else:
+        response = _get_actual_response_class(route)(
+            content,
+            status_code=response_info.status_code,
+            background=background_tasks,
+        )
+    response.media_type = response_info.media_type
+    if "content-type" in response.headers:
+        del response.headers["content-type"]
+    response.headers.raw.extend(response_info.headers.raw)
+    if not is_body_allowed_for_status_code(response.status_code):
+        response.body = b""
+    return response
 
 
 APIVersionVarType: TypeAlias = Union[ContextVar[Union[VersionType, None]], ContextVar[VersionType]]
@@ -428,7 +508,7 @@ class VersionBundle:
         *,
         exit_stack: AsyncExitStack,
         embed_body_fields: bool,
-        background_tasks: BackgroundTasks,
+        background_tasks: Union[BackgroundTasks, None],
     ) -> dict[str, Any]:
         start = self.reversed_version_values.index(current_version)
         head_route_id = id(head_route)
@@ -452,9 +532,6 @@ class VersionBundle:
             body_for_solving = request_info.body
 
         # Remember this: if len(body_params) == 1, then route.body_schema == route.dependant.body_params[0]
-        # FastAPI has already resolved these dependencies with the same holder. Preserve its tasks so this second
-        # resolution can validate the migrated request without scheduling dependency background tasks twice.
-        background_tasks_before_resolving_head_dependencies = list(background_tasks.tasks)
         result = await solve_dependencies(
             request=request,
             response=response,
@@ -465,7 +542,6 @@ class VersionBundle:
             embed_body_fields=embed_body_fields,
             background_tasks=background_tasks,
         )
-        background_tasks.tasks[:] = background_tasks_before_resolving_head_dependencies
         if result.errors:
             raise CadwynHeadRequestValidationError(result.errors, body=request_info.body, version=current_version)
         return result.values
@@ -506,11 +582,11 @@ class VersionBundle:
         dependant_for_request_migrations: Dependant,
         *,
         request_param_name: str,
-        background_tasks_param_name: str,
+        background_tasks_param_name: Union[str, None],
         response_param_name: str,
     ) -> "Callable[[Endpoint[_P, _R]], Callable[..., Coroutine[Any, Any, _R]]]":
         def wrapper(endpoint: "Endpoint[_P, _R]") -> "Callable[..., Coroutine[Any, Any, _R]]":
-            background_tasks_param_is_synthetic = (
+            background_tasks_param_is_synthetic = background_tasks_param_name is not None and (
                 background_tasks_param_name not in inspect.signature(endpoint).parameters
             )
 
@@ -518,7 +594,9 @@ class VersionBundle:
             async def decorator(*args: Any, **kwargs: Any) -> _R:
                 request_param: FastapiRequest = kwargs[request_param_name]
                 response_param: FastapiResponse = kwargs[response_param_name]
-                background_tasks: BackgroundTasks = kwargs[background_tasks_param_name]
+                background_tasks: Union[BackgroundTasks, None] = (
+                    kwargs[background_tasks_param_name] if background_tasks_param_name is not None else None
+                )
                 method = request_param.method
                 response = Sentinel
                 async with AsyncExitStack() as exit_stack:
@@ -565,7 +643,7 @@ class VersionBundle:
                 _add_keyword_only_parameter(decorator, _CADWYN_REQUEST_PARAM_NAME, FastapiRequest)
             if response_param_name == _CADWYN_RESPONSE_PARAM_NAME:
                 _add_keyword_only_parameter(decorator, _CADWYN_RESPONSE_PARAM_NAME, FastapiResponse)
-            if background_tasks_param_is_synthetic:
+            if background_tasks_param_is_synthetic and background_tasks_param_name is not None:
                 _add_keyword_only_parameter(decorator, background_tasks_param_name, BackgroundTasks)
 
             return decorator
@@ -583,7 +661,7 @@ class VersionBundle:
         kwargs: dict[str, Any],
         fastapi_response_dependency: FastapiResponse,
         *,
-        background_tasks: BackgroundTasks,
+        background_tasks: Union[BackgroundTasks, None],
     ) -> Any:
         raised_exception = None
         if response_param_name == _CADWYN_RESPONSE_PARAM_NAME:
@@ -609,7 +687,9 @@ class VersionBundle:
         if api_version is None:
             return response_or_response_body
 
+        initial_content_type: Union[str, None] = None
         if isinstance(response_or_response_body, FastapiResponse):
+            initial_content_type = response_or_response_body.headers.get("content-type")
             # TODO (https://github.com/zmievsa/cadwyn/issues/125): Add support for migrating `StreamingResponse`
             # TODO (https://github.com/zmievsa/cadwyn/issues/126): Add support for migrating `FileResponse`
             # Starlette breaks Liskov Substitution principle and
@@ -629,7 +709,7 @@ class VersionBundle:
                 body = None
                 # TODO (https://github.com/zmievsa/cadwyn/issues/51): Only do this if there are migrations
 
-            response_info = ResponseInfo(response_or_response_body, body, _background_tasks=background_tasks)
+            response_info = ResponseInfo(response_or_response_body, body)
         else:
             if fastapi_response_dependency.status_code is not None:
                 status_code = fastapi_response_dependency.status_code
@@ -639,39 +719,37 @@ class VersionBundle:
                 raise NotImplementedError
             else:
                 status_code = 200
+            body = _prepare_response_content(
+                response_or_response_body,
+                exclude_unset=head_route.response_model_exclude_unset,
+                exclude_defaults=head_route.response_model_exclude_defaults,
+                exclude_none=head_route.response_model_exclude_none,
+            )
+            response_class = _get_actual_response_class(route)
+            media_type_resolver = None
+            if response_class.media_type is None and response_class.__init__ is not FastapiResponse.__init__:
+                media_type_resolver = functools.partial(
+                    _get_response_metadata,
+                    route,
+                    status_code,
+                    background_tasks,
+                )
+            fastapi_response_dependency.charset = response_class.charset
+            fastapi_response_dependency.media_type = response_class.media_type
             fastapi_response_dependency.status_code = status_code
             response_info = ResponseInfo(
                 fastapi_response_dependency,
-                _prepare_response_content(
-                    response_or_response_body,
-                    exclude_unset=head_route.response_model_exclude_unset,
-                    exclude_defaults=head_route.response_model_exclude_defaults,
-                    exclude_none=head_route.response_model_exclude_none,
-                ),
-                _background_tasks=background_tasks,
+                body,
+                _media_type_resolver=media_type_resolver,
             )
 
-        background_before_migration = response_info.background
-        effective_background_tasks_before_migration = (
-            tuple(background_before_migration.tasks)
-            if isinstance(background_before_migration, BackgroundTasks)
-            else None
-        )
-        fastapi_background_tasks_before_migration = tuple(background_tasks.tasks)
         response_info = self._migrate_response(
             response_info,
             api_version,
             head_route.response_model,
             head_route,
         )
-        effective_background_tasks_after_migration = (
-            tuple(response_info.background.tasks) if isinstance(response_info.background, BackgroundTasks) else None
-        )
-        background_was_migrated = (
-            response_info.background is not background_before_migration
-            or effective_background_tasks_after_migration != effective_background_tasks_before_migration
-            or tuple(background_tasks.tasks) != fastapi_background_tasks_before_migration
-        )
+        media_type_was_migrated = response_info._media_type_was_set
 
         if isinstance(response_or_response_body, FastapiResponse):
             # a webserver (uvicorn for instance) calculates the body at the endpoint level.
@@ -686,10 +764,12 @@ class VersionBundle:
             # that do not have it. We don't support it too.
             if response_info.body is not None and hasattr(response_info._response, "body"):
                 # TODO (https://github.com/zmievsa/cadwyn/issues/51): Only do this if there are migrations
-                if (
-                    isinstance(response_info.body, str)
-                    and response_info._response.headers.get("content-type") != "application/json"
-                ):
+                content_type_for_rendering = (
+                    initial_content_type
+                    if response_info._media_type_was_set
+                    else response_info._response.headers.get("content-type")
+                )
+                if isinstance(response_info.body, str) and content_type_for_rendering != "application/json":
                     response_info._response.body = response_info.body.encode(response_info._response.charset)
                 else:
                     response_info._response.body = json.dumps(
@@ -715,10 +795,10 @@ class VersionBundle:
                 raised_exception.headers = dict(response_info.headers)
                 raised_exception.status_code = response_info.status_code
 
-                if not background_was_migrated:
-                    raise raised_exception
-            response_info._response.background = response_info.background
+                raise raised_exception
             return response_info._response
+        if media_type_was_migrated:
+            return await _materialize_response(response_info, route, background_tasks)
         return response_info.body
 
     async def _convert_endpoint_kwargs_to_version(
@@ -734,14 +814,14 @@ class VersionBundle:
         *,
         exit_stack: AsyncExitStack,
         embed_body_fields: bool,
-        background_tasks: BackgroundTasks,
-        background_tasks_param_name: str,
+        background_tasks: Union[BackgroundTasks, None],
+        background_tasks_param_name: Union[str, None],
         background_tasks_param_is_synthetic: bool,
     ) -> dict[str, Any]:
         request: FastapiRequest = kwargs[request_param_name]
         if request_param_name == _CADWYN_REQUEST_PARAM_NAME:
             kwargs.pop(request_param_name)
-        if background_tasks_param_is_synthetic:
+        if background_tasks_param_is_synthetic and background_tasks_param_name is not None:
             kwargs.pop(background_tasks_param_name, None)
 
         api_version = self.api_version_var.get()
@@ -779,13 +859,15 @@ class VersionBundle:
             head_route,
             exit_stack=exit_stack,
             embed_body_fields=embed_body_fields,
-            background_tasks=background_tasks,
+            background_tasks=None,
         )
         # Because we re-added it into our kwargs when we did solve_dependencies
         if _CADWYN_REQUEST_PARAM_NAME in new_kwargs:
             new_kwargs.pop(_CADWYN_REQUEST_PARAM_NAME)
-        if background_tasks_param_is_synthetic:
+        if background_tasks_param_name is not None and background_tasks_param_is_synthetic:
             new_kwargs.pop(background_tasks_param_name, None)
+        elif background_tasks_param_name is not None:
+            new_kwargs[background_tasks_param_name] = background_tasks
 
         return new_kwargs
 

--- a/cadwyn/structure/versions.py
+++ b/cadwyn/structure/versions.py
@@ -623,7 +623,7 @@ class VersionBundle:
                 body = None
                 # TODO (https://github.com/zmievsa/cadwyn/issues/51): Only do this if there are migrations
 
-            response_info = ResponseInfo(response_or_response_body, body)
+            response_info = ResponseInfo(response_or_response_body, body, _background_tasks=background_tasks)
         else:
             if fastapi_response_dependency.status_code is not None:
                 status_code = fastapi_response_dependency.status_code
@@ -695,6 +695,7 @@ class VersionBundle:
                 raised_exception.status_code = response_info.status_code
 
                 raise raised_exception
+            response_info._response.background = response_info.background
             return response_info._response
         return response_info.body
 
@@ -819,9 +820,15 @@ def _add_keyword_only_parameter(
     param_annotation: type,
 ):
     signature = inspect.signature(func)
+    parameters = list(signature.parameters.values())
+    variadic_keyword_index = next(
+        (index for index, parameter in enumerate(parameters) if parameter.kind is inspect.Parameter.VAR_KEYWORD),
+        len(parameters),
+    )
+    parameters.insert(
+        variadic_keyword_index,
+        inspect.Parameter(param_name, kind=inspect.Parameter.KEYWORD_ONLY, annotation=param_annotation),
+    )
     func.__signature__ = signature.replace(  # ty: ignore[unresolved-attribute]
-        parameters=[
-            *list(signature.parameters.values()),
-            inspect.Parameter(param_name, kind=inspect._ParameterKind.KEYWORD_ONLY, annotation=param_annotation),
-        ]
+        parameters=parameters
     )

--- a/cadwyn/structure/versions.py
+++ b/cadwyn/structure/versions.py
@@ -510,6 +510,10 @@ class VersionBundle:
         response_param_name: str,
     ) -> "Callable[[Endpoint[_P, _R]], Callable[..., Coroutine[Any, Any, _R]]]":
         def wrapper(endpoint: "Endpoint[_P, _R]") -> "Callable[..., Coroutine[Any, Any, _R]]":
+            background_tasks_param_is_synthetic = (
+                background_tasks_param_name not in inspect.signature(endpoint).parameters
+            )
+
             @functools.wraps(endpoint)
             async def decorator(*args: Any, **kwargs: Any) -> _R:
                 request_param: FastapiRequest = kwargs[request_param_name]
@@ -532,6 +536,8 @@ class VersionBundle:
                         exit_stack=exit_stack,
                         embed_body_fields=route._embed_body_fields,
                         background_tasks=background_tasks,
+                        background_tasks_param_name=background_tasks_param_name,
+                        background_tasks_param_is_synthetic=background_tasks_param_is_synthetic,
                     )
 
                     response = await self._convert_endpoint_response_to_version(
@@ -559,8 +565,8 @@ class VersionBundle:
                 _add_keyword_only_parameter(decorator, _CADWYN_REQUEST_PARAM_NAME, FastapiRequest)
             if response_param_name == _CADWYN_RESPONSE_PARAM_NAME:
                 _add_keyword_only_parameter(decorator, _CADWYN_RESPONSE_PARAM_NAME, FastapiResponse)
-            if background_tasks_param_name == _CADWYN_BACKGROUND_TASKS_PARAM_NAME:
-                _add_keyword_only_parameter(decorator, _CADWYN_BACKGROUND_TASKS_PARAM_NAME, BackgroundTasks)
+            if background_tasks_param_is_synthetic:
+                _add_keyword_only_parameter(decorator, background_tasks_param_name, BackgroundTasks)
 
             return decorator
 
@@ -645,11 +651,26 @@ class VersionBundle:
                 _background_tasks=background_tasks,
             )
 
+        background_before_migration = response_info.background
+        effective_background_tasks_before_migration = (
+            tuple(background_before_migration.tasks)
+            if isinstance(background_before_migration, BackgroundTasks)
+            else None
+        )
+        fastapi_background_tasks_before_migration = tuple(background_tasks.tasks)
         response_info = self._migrate_response(
             response_info,
             api_version,
             head_route.response_model,
             head_route,
+        )
+        effective_background_tasks_after_migration = (
+            tuple(response_info.background.tasks) if isinstance(response_info.background, BackgroundTasks) else None
+        )
+        background_was_migrated = (
+            response_info.background is not background_before_migration
+            or effective_background_tasks_after_migration != effective_background_tasks_before_migration
+            or tuple(background_tasks.tasks) != fastapi_background_tasks_before_migration
         )
 
         if isinstance(response_or_response_body, FastapiResponse):
@@ -694,7 +715,8 @@ class VersionBundle:
                 raised_exception.headers = dict(response_info.headers)
                 raised_exception.status_code = response_info.status_code
 
-                raise raised_exception
+                if not background_was_migrated:
+                    raise raised_exception
             response_info._response.background = response_info.background
             return response_info._response
         return response_info.body
@@ -713,11 +735,14 @@ class VersionBundle:
         exit_stack: AsyncExitStack,
         embed_body_fields: bool,
         background_tasks: BackgroundTasks,
+        background_tasks_param_name: str,
+        background_tasks_param_is_synthetic: bool,
     ) -> dict[str, Any]:
         request: FastapiRequest = kwargs[request_param_name]
         if request_param_name == _CADWYN_REQUEST_PARAM_NAME:
             kwargs.pop(request_param_name)
-        kwargs.pop(_CADWYN_BACKGROUND_TASKS_PARAM_NAME, None)
+        if background_tasks_param_is_synthetic:
+            kwargs.pop(background_tasks_param_name, None)
 
         api_version = self.api_version_var.get()
         if api_version is None:
@@ -759,8 +784,8 @@ class VersionBundle:
         # Because we re-added it into our kwargs when we did solve_dependencies
         if _CADWYN_REQUEST_PARAM_NAME in new_kwargs:
             new_kwargs.pop(_CADWYN_REQUEST_PARAM_NAME)
-        if _CADWYN_BACKGROUND_TASKS_PARAM_NAME in new_kwargs:
-            new_kwargs.pop(_CADWYN_BACKGROUND_TASKS_PARAM_NAME)
+        if background_tasks_param_is_synthetic:
+            new_kwargs.pop(background_tasks_param_name, None)
 
         return new_kwargs
 

--- a/cadwyn/structure/versions.py
+++ b/cadwyn/structure/versions.py
@@ -52,6 +52,7 @@ from .schemas import AlterSchemaSubInstruction, SchemaHadInstruction
 
 _CADWYN_REQUEST_PARAM_NAME = "cadwyn_request_param"
 _CADWYN_RESPONSE_PARAM_NAME = "cadwyn_response_param"
+_CADWYN_BACKGROUND_TASKS_PARAM_NAME = "cadwyn_background_tasks_param"
 _P = ParamSpec("_P")
 _R = TypeVar("_R")
 _RouteId = int
@@ -539,6 +540,7 @@ class VersionBundle:
                         response_param_name,
                         kwargs,
                         response_param,
+                        background_tasks=background_tasks,
                     )
                 if response is Sentinel:  # pragma: no cover
                     raise CadwynError(
@@ -555,6 +557,8 @@ class VersionBundle:
                 _add_keyword_only_parameter(decorator, _CADWYN_REQUEST_PARAM_NAME, FastapiRequest)
             if response_param_name == _CADWYN_RESPONSE_PARAM_NAME:
                 _add_keyword_only_parameter(decorator, _CADWYN_RESPONSE_PARAM_NAME, FastapiResponse)
+            if background_tasks_param_name == _CADWYN_BACKGROUND_TASKS_PARAM_NAME:
+                _add_keyword_only_parameter(decorator, _CADWYN_BACKGROUND_TASKS_PARAM_NAME, BackgroundTasks)
 
             return decorator
 
@@ -570,6 +574,8 @@ class VersionBundle:
         response_param_name: str,
         kwargs: dict[str, Any],
         fastapi_response_dependency: FastapiResponse,
+        *,
+        background_tasks: Union[BackgroundTasks, None],
     ) -> Any:
         raised_exception = None
         if response_param_name == _CADWYN_RESPONSE_PARAM_NAME:
@@ -634,6 +640,7 @@ class VersionBundle:
                     exclude_defaults=head_route.response_model_exclude_defaults,
                     exclude_none=head_route.response_model_exclude_none,
                 ),
+                _background_tasks=background_tasks,
             )
 
         response_info = self._migrate_response(
@@ -707,6 +714,7 @@ class VersionBundle:
         request: FastapiRequest = kwargs[request_param_name]
         if request_param_name == _CADWYN_REQUEST_PARAM_NAME:
             kwargs.pop(request_param_name)
+        kwargs.pop(_CADWYN_BACKGROUND_TASKS_PARAM_NAME, None)
 
         api_version = self.api_version_var.get()
         if api_version is None:
@@ -748,6 +756,8 @@ class VersionBundle:
         # Because we re-added it into our kwargs when we did solve_dependencies
         if _CADWYN_REQUEST_PARAM_NAME in new_kwargs:
             new_kwargs.pop(_CADWYN_REQUEST_PARAM_NAME)
+        if _CADWYN_BACKGROUND_TASKS_PARAM_NAME in new_kwargs:
+            new_kwargs.pop(_CADWYN_BACKGROUND_TASKS_PARAM_NAME)
 
         return new_kwargs
 

--- a/cadwyn/structure/versions.py
+++ b/cadwyn/structure/versions.py
@@ -595,7 +595,6 @@ class VersionBundle:
         if api_version is None:
             return response_or_response_body
 
-        original_content_type: Union[str, None] = None
         if isinstance(response_or_response_body, FastapiResponse):
             # TODO (https://github.com/zmievsa/cadwyn/issues/125): Add support for migrating `StreamingResponse`
             # TODO (https://github.com/zmievsa/cadwyn/issues/126): Add support for migrating `FileResponse`
@@ -617,7 +616,6 @@ class VersionBundle:
                 # TODO (https://github.com/zmievsa/cadwyn/issues/51): Only do this if there are migrations
 
             response_info = ResponseInfo(response_or_response_body, body)
-            original_content_type = response_info.headers.get("content-type")
         else:
             if fastapi_response_dependency.status_code is not None:
                 status_code = fastapi_response_dependency.status_code
@@ -658,7 +656,10 @@ class VersionBundle:
             # that do not have it. We don't support it too.
             if response_info.body is not None and hasattr(response_info._response, "body"):
                 # TODO (https://github.com/zmievsa/cadwyn/issues/51): Only do this if there are migrations
-                if isinstance(response_info.body, str) and original_content_type != "application/json":
+                if (
+                    isinstance(response_info.body, str)
+                    and response_info._response.headers.get("content-type") != "application/json"
+                ):
                     response_info._response.body = response_info.body.encode(response_info._response.charset)
                 else:
                     response_info._response.body = json.dumps(

--- a/cadwyn/structure/versions.py
+++ b/cadwyn/structure/versions.py
@@ -595,6 +595,7 @@ class VersionBundle:
         if api_version is None:
             return response_or_response_body
 
+        original_content_type: Union[str, None] = None
         if isinstance(response_or_response_body, FastapiResponse):
             # TODO (https://github.com/zmievsa/cadwyn/issues/125): Add support for migrating `StreamingResponse`
             # TODO (https://github.com/zmievsa/cadwyn/issues/126): Add support for migrating `FileResponse`
@@ -616,6 +617,7 @@ class VersionBundle:
                 # TODO (https://github.com/zmievsa/cadwyn/issues/51): Only do this if there are migrations
 
             response_info = ResponseInfo(response_or_response_body, body)
+            original_content_type = response_info.headers.get("content-type")
         else:
             if fastapi_response_dependency.status_code is not None:
                 status_code = fastapi_response_dependency.status_code
@@ -656,10 +658,7 @@ class VersionBundle:
             # that do not have it. We don't support it too.
             if response_info.body is not None and hasattr(response_info._response, "body"):
                 # TODO (https://github.com/zmievsa/cadwyn/issues/51): Only do this if there are migrations
-                if (
-                    isinstance(response_info.body, str)
-                    and response_info._response.headers.get("content-type") != "application/json"
-                ):
+                if isinstance(response_info.body, str) and original_content_type != "application/json":
                     response_info._response.body = response_info.body.encode(response_info._response.charset)
                 else:
                     response_info._response.body = json.dumps(

--- a/docs/concepts/version_changes.md
+++ b/docs/concepts/version_changes.md
@@ -305,8 +305,9 @@ Cadwyn can migrate more than just request bodies.
 * [set_cookie](https://www.starlette.io/responses/#set-cookie)
 * [delete_cookie](https://www.starlette.io/responses/#delete-cookie)
 
-`media_type` and `background` map directly to the corresponding Starlette response attributes. As in Starlette,
-changing `media_type` after response initialization does not rewrite the existing `Content-Type` header.
+`media_type` maps directly to the corresponding Starlette response attribute. As in Starlette, changing it after
+response initialization does not rewrite the existing `Content-Type` header. `background` controls the task attached
+to the final response, including when an endpoint returns a response body instead of a `Response` instance.
 
 #### Internal representations
 

--- a/docs/concepts/version_changes.md
+++ b/docs/concepts/version_changes.md
@@ -300,6 +300,8 @@ Cadwyn can migrate more than just request bodies.
 * `body: Any`
 * `status_code: int`
 * `headers: starlette.datastructures.MutableHeaders`
+* `media_type: str | None`
+* `background: starlette.background.BackgroundTask | None`
 * [set_cookie](https://www.starlette.io/responses/#set-cookie)
 * [delete_cookie](https://www.starlette.io/responses/#delete-cookie)
 

--- a/docs/concepts/version_changes.md
+++ b/docs/concepts/version_changes.md
@@ -301,13 +301,11 @@ Cadwyn can migrate more than just request bodies.
 * `status_code: int`
 * `headers: starlette.datastructures.MutableHeaders`
 * `media_type: str | None`
-* `background: starlette.background.BackgroundTask | None`
 * [set_cookie](https://www.starlette.io/responses/#set-cookie)
 * [delete_cookie](https://www.starlette.io/responses/#delete-cookie)
 
-`media_type` maps directly to the corresponding Starlette response attribute. As in Starlette, changing it after
-response initialization does not rewrite the existing `Content-Type` header. `background` controls the task attached
-to the final response, including when an endpoint returns a response body instead of a `Response` instance.
+Changing `media_type` also updates the final response's `Content-Type` header, whether the endpoint returns a
+Starlette response or an ordinary response body.
 
 #### Internal representations
 

--- a/docs/concepts/version_changes.md
+++ b/docs/concepts/version_changes.md
@@ -305,6 +305,9 @@ Cadwyn can migrate more than just request bodies.
 * [set_cookie](https://www.starlette.io/responses/#set-cookie)
 * [delete_cookie](https://www.starlette.io/responses/#delete-cookie)
 
+`media_type` and `background` map directly to the corresponding Starlette response attributes. As in Starlette,
+changing `media_type` after response initialization does not rewrite the existing `Content-Type` header.
+
 #### Internal representations
 
 So far, only simple cases were reviewed above. But what happens if you cannot migrate your data that easily? It can happen because your earlier versions had **more data** than your newer versions. Or that data had more formats.

--- a/tests/test_data_migrations.py
+++ b/tests/test_data_migrations.py
@@ -14,6 +14,7 @@ from fastapi import (
     BackgroundTasks,
     Body,
     Cookie,
+    Depends,
     File,
     Form,
     Header,
@@ -476,6 +477,56 @@ class TestResponseMigrations:
 
         assert clients["2000-01-01"].get(test_path).json() == {"message": "hello"}
         assert completed_tasks == ["migrated"]
+
+    def test__response_background_migration__keeps_assigned_background_tasks_live(
+        self,
+        create_versioned_clients: CreateVersionedClients,
+        test_path: Literal["/test"],
+        router: VersionedAPIRouter,
+    ):
+        completed_tasks: list[str] = []
+
+        @router.get(test_path)
+        async def endpoint():
+            return {"message": "hello"}
+
+        @convert_response_to_previous_version_for(test_path, ["GET"])
+        def migrator(response: ResponseInfo):
+            migrated_background = BackgroundTasks()
+            response.background = migrated_background
+            migrated_background.add_task(completed_tasks.append, "migrated")
+
+        clients = create_versioned_clients(version_change(migrator=migrator))
+
+        assert clients["2000-01-01"].get(test_path).json() == {"message": "hello"}
+        assert completed_tasks == ["migrated"]
+
+    def test__response_background_migration__does_not_duplicate_tasks_added_by_dependencies(
+        self,
+        create_versioned_clients: CreateVersionedClients,
+        test_path: Literal["/test"],
+        router: VersionedAPIRouter,
+    ):
+        completed_tasks: list[str] = []
+
+        def dependency(background_tasks: BackgroundTasks) -> None:
+            background_tasks.add_task(completed_tasks.append, "dependency")
+
+        @router.get(test_path)
+        async def endpoint(_dependency: None = Depends(dependency)):
+            return {"message": "hello"}
+
+        @convert_response_to_previous_version_for(test_path, ["GET"])
+        def migrator(response: ResponseInfo):
+            assert response.background is not None
+
+        clients = create_versioned_clients(version_change(migrator=migrator))
+
+        assert clients["2000-01-01"].get(test_path).json() == {"message": "hello"}
+        assert completed_tasks == ["dependency"]
+
+        assert clients["2001-01-01"].get(test_path).json() == {"message": "hello"}
+        assert completed_tasks == ["dependency", "dependency"]
 
     def test__response_background_migration__removes_tasks_for_an_ordinary_response_body(
         self,

--- a/tests/test_data_migrations.py
+++ b/tests/test_data_migrations.py
@@ -384,21 +384,11 @@ class TestRequestMigrations:
 
 
 class TestResponseMigrations:
-    @pytest.mark.parametrize(
-        ("migrated_media_type", "expected_content_type"),
-        [
-            ("application/vnd.cadwyn.v1+json", "application/vnd.cadwyn.v1+json"),
-            ("text/vnd.cadwyn", "text/vnd.cadwyn; charset=utf-8"),
-            (None, None),
-        ],
-    )
-    def test__response_media_type_migration__updates_the_public_response(
+    def test__response_media_type_migration__updates_the_public_attribute(
         self,
         create_versioned_clients: CreateVersionedClients,
         test_path: Literal["/test"],
         router: VersionedAPIRouter,
-        migrated_media_type: Union[str, None],
-        expected_content_type: Union[str, None],
     ):
         @router.get(test_path)
         async def endpoint():
@@ -407,13 +397,13 @@ class TestResponseMigrations:
         @convert_response_to_previous_version_for(test_path, ["GET"])
         def migrator(response: ResponseInfo):
             assert response.media_type == "application/json"
-            response.media_type = migrated_media_type
-            assert response.media_type == migrated_media_type
+            response.media_type = "text/vnd.cadwyn"
+            assert response.media_type == "text/vnd.cadwyn"
 
         clients = create_versioned_clients(version_change(migrator=migrator))
 
         migrated_response = clients["2000-01-01"].get(test_path)
-        assert migrated_response.headers.get("content-type") == expected_content_type
+        assert migrated_response.headers["content-type"] == "application/json"
         assert migrated_response.json() == "hello"
 
         latest_response = clients["2001-01-01"].get(test_path)

--- a/tests/test_data_migrations.py
+++ b/tests/test_data_migrations.py
@@ -9,7 +9,20 @@ from typing import Any, Literal, Optional, Union
 import fastapi
 import pytest
 from dirty_equals import IsPartialDict, IsStr
-from fastapi import APIRouter, Body, Cookie, File, Form, Header, HTTPException, Query, Request, Response, UploadFile
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Body,
+    Cookie,
+    File,
+    Form,
+    Header,
+    HTTPException,
+    Query,
+    Request,
+    Response,
+    UploadFile,
+)
 from fastapi.responses import JSONResponse
 from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
@@ -441,6 +454,57 @@ class TestResponseMigrations:
 
         assert clients["2001-01-01"].get(test_path).json() == {"message": "hello"}
         assert completed_tasks == ["migrated", "original"]
+
+    def test__response_background_migration__replaces_tasks_for_an_ordinary_response_body(
+        self,
+        create_versioned_clients: CreateVersionedClients,
+        test_path: Literal["/test"],
+        router: VersionedAPIRouter,
+    ):
+        completed_tasks: list[str] = []
+
+        @router.get(test_path)
+        async def endpoint():
+            return {"message": "hello"}
+
+        @convert_response_to_previous_version_for(test_path, ["GET"])
+        def migrator(response: ResponseInfo):
+            assert response.background is None
+            response.background = BackgroundTask(completed_tasks.append, "migrated")
+
+        clients = create_versioned_clients(version_change(migrator=migrator))
+
+        assert clients["2000-01-01"].get(test_path).json() == {"message": "hello"}
+        assert completed_tasks == ["migrated"]
+
+    def test__response_background_migration__removes_tasks_for_an_ordinary_response_body(
+        self,
+        create_versioned_clients: CreateVersionedClients,
+        test_path: Literal["/test"],
+        router: VersionedAPIRouter,
+    ):
+        completed_tasks: list[str] = []
+
+        @router.get(test_path)
+        async def endpoint(background_tasks: BackgroundTasks):
+            background_tasks.add_task(completed_tasks.append, "original")
+            return {"message": "hello"}
+
+        @convert_response_to_previous_version_for(test_path, ["GET"])
+        def migrator(response: ResponseInfo):
+            background = response.background
+            assert background is not None
+            response.background = background
+            assert response.background is background
+            response.background = None
+
+        clients = create_versioned_clients(version_change(migrator=migrator))
+
+        assert clients["2000-01-01"].get(test_path).json() == {"message": "hello"}
+        assert completed_tasks == []
+
+        assert clients["2001-01-01"].get(test_path).json() == {"message": "hello"}
+        assert completed_tasks == ["original"]
 
     def test__all_response_components_migration__post_endpoint__migration_filled_results_up(
         self,

--- a/tests/test_data_migrations.py
+++ b/tests/test_data_migrations.py
@@ -4,6 +4,7 @@ import sys
 from collections.abc import Callable, Coroutine
 from contextvars import ContextVar
 from io import StringIO
+from pathlib import Path
 from typing import Any, Literal, Optional, Union
 
 import fastapi
@@ -24,10 +25,10 @@ from fastapi import (
     Response,
     UploadFile,
 )
-from fastapi.responses import JSONResponse
+from fastapi.responses import FileResponse, JSONResponse
 from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
-from pydantic import BaseModel, Field, RootModel
+from pydantic import BaseModel, Field, RootModel, field_serializer
 from starlette.background import BackgroundTask
 from starlette.responses import StreamingResponse
 
@@ -398,148 +399,242 @@ class TestRequestMigrations:
 
 
 class TestResponseMigrations:
-    def test__response_background__maps_directly_to_response_without_fastapi_background_tasks(self):
-        original_background = BackgroundTask(lambda: None)
-        migrated_background = BackgroundTask(lambda: None)
-        response = Response(background=original_background)
-        response_info = ResponseInfo(response, body=None)
-
-        assert response_info.background is original_background
-        response_info.background = migrated_background
-        assert response_info.background is migrated_background
-        assert response.background is migrated_background
-
-    def test__response_media_type_migration__updates_the_public_attribute(
+    @pytest.mark.parametrize("returns_response", [False, True])
+    def test__response_media_type_migration__updates_the_final_response(
         self,
         create_versioned_clients: CreateVersionedClients,
         test_path: Literal["/test"],
         router: VersionedAPIRouter,
+        *,
+        returns_response: bool,
     ):
-        @router.get(test_path)
-        async def endpoint():
-            return JSONResponse("hello")
+        completed_tasks: list[str] = []
+
+        def add_background_task(background_tasks: BackgroundTasks) -> None:
+            background_tasks.add_task(completed_tasks.append, "completed")
+
+        if returns_response:
+
+            @router.get(test_path)
+            async def endpoint(_: None = Depends(add_background_task)):
+                return JSONResponse("hello")
+
+        else:
+
+            @router.get(test_path)
+            async def endpoint(_: None = Depends(add_background_task)) -> str:
+                return "hello"
 
         @convert_response_to_previous_version_for(test_path, ["GET"])
         def migrator(response: ResponseInfo):
             assert response.media_type == "application/json"
             response.media_type = "text/vnd.cadwyn"
             assert response.media_type == "text/vnd.cadwyn"
+            response.headers["content-type"] = "text/vnd.cadwyn; profile=legacy"
 
         clients = create_versioned_clients(version_change(migrator=migrator))
 
         migrated_response = clients["2000-01-01"].get(test_path)
-        assert migrated_response.headers["content-type"] == "application/json"
+        assert migrated_response.headers.get_list("content-type") == ["text/vnd.cadwyn; profile=legacy"]
         assert migrated_response.json() == "hello"
+        assert completed_tasks == ["completed"]
 
         latest_response = clients["2001-01-01"].get(test_path)
         assert latest_response.headers["content-type"] == "application/json"
         assert latest_response.json() == "hello"
+        assert completed_tasks == ["completed", "completed"]
 
-    def test__response_background_migration__replaces_the_public_response_task(
+    def test__response_media_type_migration__resolves_file_response_media_type(
         self,
         create_versioned_clients: CreateVersionedClients,
         test_path: Literal["/test"],
         router: VersionedAPIRouter,
+        tmp_path: Path,
     ):
-        completed_tasks: list[str] = []
+        response_path = tmp_path / "response.txt"
+        response_path.write_text("hello")
 
-        def record_completed_task(task_name: str) -> None:
-            completed_tasks.append(task_name)
-
-        original_background = BackgroundTask(record_completed_task, "original")
-        migrated_background = BackgroundTask(record_completed_task, "migrated")
-
-        @router.get(test_path)
+        @router.get(test_path, response_class=FileResponse)
         async def endpoint():
-            return JSONResponse({"message": "hello"}, background=original_background)
+            return response_path
 
         @convert_response_to_previous_version_for(test_path, ["GET"])
         def migrator(response: ResponseInfo):
-            assert response.background is original_background
-            response.background = migrated_background
-            assert response.background is migrated_background
+            assert response.media_type == "text/plain"
+            response.media_type = "text/vnd.cadwyn"
 
         clients = create_versioned_clients(version_change(migrator=migrator))
 
-        assert clients["2000-01-01"].get(test_path).json() == {"message": "hello"}
-        assert completed_tasks == ["migrated"]
+        migrated_response = clients["2000-01-01"].get(test_path)
+        assert migrated_response.headers.get_list("content-type") == ["text/vnd.cadwyn; charset=utf-8"]
+        assert migrated_response.text == "hello"
 
-        assert clients["2001-01-01"].get(test_path).json() == {"message": "hello"}
-        assert completed_tasks == ["migrated", "original"]
+        latest_response = clients["2001-01-01"].get(test_path)
+        assert latest_response.headers["content-type"] == "text/plain; charset=utf-8"
+        assert latest_response.text == "hello"
 
-    def test__response_background_migration__replaces_tasks_for_an_ordinary_response_body(
+    def test__response_media_type_migration__uses_response_class_charset(
         self,
         create_versioned_clients: CreateVersionedClients,
         test_path: Literal["/test"],
         router: VersionedAPIRouter,
     ):
-        completed_tasks: list[str] = []
+        class LatinResponse(Response):
+            media_type = "text/plain"
+            charset = "iso-8859-1"
 
-        @router.get(test_path)
-        async def endpoint():
-            return {"message": "hello"}
+        @router.get(test_path, response_class=LatinResponse)
+        async def endpoint() -> str:
+            return "olá"
 
         @convert_response_to_previous_version_for(test_path, ["GET"])
         def migrator(response: ResponseInfo):
-            assert response.background is None
-            response.background = BackgroundTask(completed_tasks.append, "migrated")
+            assert response.media_type == "text/plain"
+            response.media_type = "text/vnd.cadwyn"
 
         clients = create_versioned_clients(version_change(migrator=migrator))
 
-        assert clients["2000-01-01"].get(test_path).json() == {"message": "hello"}
-        assert completed_tasks == ["migrated"]
+        migrated_response = clients["2000-01-01"].get(test_path)
+        assert migrated_response.headers["content-type"] == "text/vnd.cadwyn; charset=iso-8859-1"
+        assert migrated_response.content == b"ol\xe1"
 
-    def test__response_background_migration__keeps_assigned_background_tasks_live(
+        latest_response = clients["2001-01-01"].get(test_path)
+        assert latest_response.headers["content-type"] == "text/plain; charset=iso-8859-1"
+        assert latest_response.content == b"ol\xe1"
+
+    def test__response_media_type_migration__supports_required_background_constructor_parameter(
         self,
         create_versioned_clients: CreateVersionedClients,
         test_path: Literal["/test"],
         router: VersionedAPIRouter,
     ):
-        completed_tasks: list[str] = []
+        response_initializations = 0
 
-        @router.get(test_path)
-        async def endpoint():
-            return {"message": "hello"}
+        class DynamicResponse(Response):
+            media_type = None
+
+            def __init__(
+                self,
+                content: str,
+                status_code: int = 200,
+                *,
+                background: Union[BackgroundTask, None],
+            ):
+                nonlocal response_initializations
+                response_initializations += 1
+                super().__init__(content, status_code, media_type="text/dynamic", background=background)
+
+        @router.get(test_path, response_class=DynamicResponse)
+        async def endpoint() -> str:
+            return "hello"
 
         @convert_response_to_previous_version_for(test_path, ["GET"])
         def migrator(response: ResponseInfo):
-            migrated_background = BackgroundTasks()
-            response.background = migrated_background
-            migrated_background.add_task(completed_tasks.append, "migrated")
+            assert response.media_type == "text/dynamic"
+            response.media_type = "text/vnd.cadwyn"
 
         clients = create_versioned_clients(version_change(migrator=migrator))
 
-        assert clients["2000-01-01"].get(test_path).json() == {"message": "hello"}
-        assert completed_tasks == ["migrated"]
+        migrated_response = clients["2000-01-01"].get(test_path)
+        assert migrated_response.headers["content-type"] == "text/vnd.cadwyn; charset=utf-8"
+        assert migrated_response.text == "hello"
+        assert response_initializations == 2
 
-    def test__response_background_migration__does_not_duplicate_tasks_added_by_dependencies(
+        latest_response = clients["2001-01-01"].get(test_path)
+        assert latest_response.headers["content-type"] == "text/dynamic; charset=utf-8"
+        assert latest_response.text == "hello"
+        assert response_initializations == 3
+
+    def test__response_media_type_migration__probes_with_serialized_content(
+        self,
+        create_versioned_clients: CreateVersionedClients,
+        test_path: Literal["/test"],
+        router: VersionedAPIRouter,
+    ):
+        class ResponseModel(BaseModel):
+            value: int
+
+            @field_serializer("value")
+            def serialize_value(self, value: int) -> str:
+                return f"value={value}"
+
+        class SerializedContentResponse(Response):
+            media_type = None
+
+            def __init__(
+                self,
+                content: dict[str, str],
+                status_code: int = 200,
+                *,
+                background: Union[BackgroundTask, None],
+            ):
+                assert content == {"value": "value=1"}
+                super().__init__(content["value"], status_code, media_type="text/plain", background=background)
+
+        @router.get(test_path, response_model=ResponseModel, response_class=SerializedContentResponse)
+        async def endpoint() -> dict[str, int]:
+            return {"value": 1}
+
+        @convert_response_to_previous_version_for(test_path, ["GET"])
+        def migrator(response: ResponseInfo):
+            assert response.media_type == "text/plain"
+            response.media_type = "text/vnd.cadwyn"
+
+        clients = create_versioned_clients(version_change(migrator=migrator))
+
+        migrated_response = clients["2000-01-01"].get(test_path)
+        assert migrated_response.headers["content-type"] == "text/vnd.cadwyn; charset=utf-8"
+        assert migrated_response.text == "value=1"
+
+        latest_response = clients["2001-01-01"].get(test_path)
+        assert latest_response.headers["content-type"] == "text/plain; charset=utf-8"
+        assert latest_response.text == "value=1"
+
+    def test__response_media_type_migration__preserves_dependency_background_tasks(
         self,
         create_versioned_clients: CreateVersionedClients,
         test_path: Literal["/test"],
         router: VersionedAPIRouter,
     ):
         completed_tasks: list[str] = []
+
+        class FallbackBackgroundResponse(Response):
+            media_type = "text/plain"
+
+            def __init__(
+                self,
+                content: str,
+                status_code: int = 200,
+                *,
+                background: Union[BackgroundTask, None],
+            ):
+                super().__init__(
+                    content,
+                    status_code,
+                    media_type=self.media_type,
+                    background=background or BackgroundTask(completed_tasks.append, "constructor"),
+                )
 
         def dependency(background_tasks: BackgroundTasks) -> None:
             background_tasks.add_task(completed_tasks.append, "dependency")
 
-        @router.get(test_path)
-        async def endpoint(_dependency: None = Depends(dependency)):
-            return {"message": "hello"}
+        @router.get(test_path, response_class=FallbackBackgroundResponse)
+        async def endpoint(_: None = Depends(dependency)) -> str:
+            return "hello"
 
         @convert_response_to_previous_version_for(test_path, ["GET"])
         def migrator(response: ResponseInfo):
-            assert response.background is not None
+            response.media_type = "text/vnd.cadwyn"
 
         clients = create_versioned_clients(version_change(migrator=migrator))
 
-        assert clients["2000-01-01"].get(test_path).json() == {"message": "hello"}
+        assert clients["2000-01-01"].get(test_path).text == "hello"
         assert completed_tasks == ["dependency"]
 
-        assert clients["2001-01-01"].get(test_path).json() == {"message": "hello"}
+        assert clients["2001-01-01"].get(test_path).text == "hello"
         assert completed_tasks == ["dependency", "dependency"]
 
-    def test__response_background_migration__removes_tasks_for_an_ordinary_response_body(
+    def test__response_media_type_migration__does_not_inject_an_empty_background_holder(
         self,
         create_versioned_clients: CreateVersionedClients,
         test_path: Literal["/test"],
@@ -547,54 +642,38 @@ class TestResponseMigrations:
     ):
         completed_tasks: list[str] = []
 
-        @router.get(test_path)
-        async def endpoint(background_tasks: BackgroundTasks):
-            background_tasks.add_task(completed_tasks.append, "original")
-            return {"message": "hello"}
+        class FallbackBackgroundResponse(Response):
+            media_type = "text/plain"
+
+            def __init__(
+                self,
+                content: str,
+                status_code: int = 200,
+                *,
+                background: Union[BackgroundTask, None],
+            ):
+                super().__init__(
+                    content,
+                    status_code,
+                    media_type=self.media_type,
+                    background=background or BackgroundTask(completed_tasks.append, "constructor"),
+                )
+
+        @router.get(test_path, response_class=FallbackBackgroundResponse)
+        async def endpoint() -> str:
+            return "hello"
 
         @convert_response_to_previous_version_for(test_path, ["GET"])
         def migrator(response: ResponseInfo):
-            background = response.background
-            assert background is not None
-            response.background = background
-            assert response.background is background
-            response.background = None
+            response.media_type = "text/vnd.cadwyn"
 
         clients = create_versioned_clients(version_change(migrator=migrator))
 
-        assert clients["2000-01-01"].get(test_path).json() == {"message": "hello"}
-        assert completed_tasks == []
+        assert clients["2000-01-01"].get(test_path).text == "hello"
+        assert completed_tasks == ["constructor"]
 
-        assert clients["2001-01-01"].get(test_path).json() == {"message": "hello"}
-        assert completed_tasks == ["original"]
-
-    def test__response_background_migration__removes_dependency_tasks_for_an_explicit_response(
-        self,
-        create_versioned_clients: CreateVersionedClients,
-        test_path: Literal["/test"],
-        router: VersionedAPIRouter,
-    ):
-        completed_tasks: list[str] = []
-
-        def dependency(background_tasks: BackgroundTasks) -> None:
-            background_tasks.add_task(completed_tasks.append, "original")
-
-        @router.get(test_path)
-        async def endpoint(_dependency: None = Depends(dependency)):
-            return JSONResponse({"message": "hello"})
-
-        @convert_response_to_previous_version_for(test_path, ["GET"])
-        def migrator(response: ResponseInfo):
-            assert response.background is not None
-            response.background = None
-
-        clients = create_versioned_clients(version_change(migrator=migrator))
-
-        assert clients["2000-01-01"].get(test_path).json() == {"message": "hello"}
-        assert completed_tasks == []
-
-        assert clients["2001-01-01"].get(test_path).json() == {"message": "hello"}
-        assert completed_tasks == ["original"]
+        assert clients["2001-01-01"].get(test_path).text == "hello"
+        assert completed_tasks == ["constructor", "constructor"]
 
     def test__data_migration_params__are_inserted_before_variadic_keyword_params(
         self,
@@ -1402,33 +1481,6 @@ def test__request_and_response_migrations__for_endpoint_with_http_exception__can
     resp_2001 = clients["2001-01-01"].post("/test")
     assert resp_2001.status_code == 404
     assert resp_2001.json() == {"detail": "Not Found"}
-
-
-def test__request_and_response_migrations__for_http_exception__can_add_background_task(
-    create_versioned_clients: CreateVersionedClients,
-    router: VersionedAPIRouter,
-):
-    completed_tasks: list[str] = []
-
-    @router.post("/test")
-    async def endpoint():
-        raise HTTPException(status_code=400, detail="bad request")
-
-    @convert_response_to_previous_version_for("/test", ["POST"], migrate_http_errors=True)
-    def response_converter(response: ResponseInfo):
-        response.background = BackgroundTask(completed_tasks.append, "migrated")
-
-    clients = create_versioned_clients(version_change(resp=response_converter))
-
-    resp_2000 = clients["2000-01-01"].post("/test")
-    assert resp_2000.status_code == 400
-    assert resp_2000.json() == {"detail": "bad request"}
-    assert completed_tasks == ["migrated"]
-
-    resp_2001 = clients["2001-01-01"].post("/test")
-    assert resp_2001.status_code == 400
-    assert resp_2001.json() == {"detail": "bad request"}
-    assert completed_tasks == ["migrated"]
 
 
 def test__request_and_response_migrations__for_endpoint_with_no_default_status_code__response_should_contain_default(

--- a/tests/test_data_migrations.py
+++ b/tests/test_data_migrations.py
@@ -398,6 +398,17 @@ class TestRequestMigrations:
 
 
 class TestResponseMigrations:
+    def test__response_background__maps_directly_to_response_without_fastapi_background_tasks(self):
+        original_background = BackgroundTask(lambda: None)
+        migrated_background = BackgroundTask(lambda: None)
+        response = Response(background=original_background)
+        response_info = ResponseInfo(response, body=None)
+
+        assert response_info.background is original_background
+        response_info.background = migrated_background
+        assert response_info.background is migrated_background
+        assert response.background is migrated_background
+
     def test__response_media_type_migration__updates_the_public_attribute(
         self,
         create_versioned_clients: CreateVersionedClients,
@@ -556,6 +567,49 @@ class TestResponseMigrations:
 
         assert clients["2001-01-01"].get(test_path).json() == {"message": "hello"}
         assert completed_tasks == ["original"]
+
+    def test__response_background_migration__removes_dependency_tasks_for_an_explicit_response(
+        self,
+        create_versioned_clients: CreateVersionedClients,
+        test_path: Literal["/test"],
+        router: VersionedAPIRouter,
+    ):
+        completed_tasks: list[str] = []
+
+        def dependency(background_tasks: BackgroundTasks) -> None:
+            background_tasks.add_task(completed_tasks.append, "original")
+
+        @router.get(test_path)
+        async def endpoint(_dependency: None = Depends(dependency)):
+            return JSONResponse({"message": "hello"})
+
+        @convert_response_to_previous_version_for(test_path, ["GET"])
+        def migrator(response: ResponseInfo):
+            assert response.background is not None
+            response.background = None
+
+        clients = create_versioned_clients(version_change(migrator=migrator))
+
+        assert clients["2000-01-01"].get(test_path).json() == {"message": "hello"}
+        assert completed_tasks == []
+
+        assert clients["2001-01-01"].get(test_path).json() == {"message": "hello"}
+        assert completed_tasks == ["original"]
+
+    def test__data_migration_params__are_inserted_before_variadic_keyword_params(
+        self,
+        create_versioned_clients: CreateVersionedClients,
+        test_path: Literal["/test"],
+        router: VersionedAPIRouter,
+    ):
+        @router.get(test_path)
+        async def endpoint(request: Request, response: Response, **kwargs: Any):
+            return {"message": "hello"}
+
+        clients = create_versioned_clients()
+
+        assert set(clients) == {"2000-01-01"}
+        assert clients["2000-01-01"].get(test_path, params={"kwargs": "value"}).json() == {"message": "hello"}
 
     def test__all_response_components_migration__post_endpoint__migration_filled_results_up(
         self,

--- a/tests/test_data_migrations.py
+++ b/tests/test_data_migrations.py
@@ -14,6 +14,7 @@ from fastapi.responses import JSONResponse
 from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
 from pydantic import BaseModel, Field, RootModel
+from starlette.background import BackgroundTask
 from starlette.responses import StreamingResponse
 
 from cadwyn import VersionedAPIRouter
@@ -383,6 +384,74 @@ class TestRequestMigrations:
 
 
 class TestResponseMigrations:
+    @pytest.mark.parametrize(
+        ("migrated_media_type", "expected_content_type"),
+        [
+            ("application/vnd.cadwyn.v1+json", "application/vnd.cadwyn.v1+json"),
+            ("text/vnd.cadwyn", "text/vnd.cadwyn; charset=utf-8"),
+            (None, None),
+        ],
+    )
+    def test__response_media_type_migration__updates_the_public_response(
+        self,
+        create_versioned_clients: CreateVersionedClients,
+        test_path: Literal["/test"],
+        router: VersionedAPIRouter,
+        migrated_media_type: Union[str, None],
+        expected_content_type: Union[str, None],
+    ):
+        @router.get(test_path)
+        async def endpoint():
+            return JSONResponse("hello")
+
+        @convert_response_to_previous_version_for(test_path, ["GET"])
+        def migrator(response: ResponseInfo):
+            assert response.media_type == "application/json"
+            response.media_type = migrated_media_type
+            assert response.media_type == migrated_media_type
+
+        clients = create_versioned_clients(version_change(migrator=migrator))
+
+        migrated_response = clients["2000-01-01"].get(test_path)
+        assert migrated_response.headers.get("content-type") == expected_content_type
+        assert migrated_response.json() == "hello"
+
+        latest_response = clients["2001-01-01"].get(test_path)
+        assert latest_response.headers["content-type"] == "application/json"
+        assert latest_response.json() == "hello"
+
+    def test__response_background_migration__replaces_the_public_response_task(
+        self,
+        create_versioned_clients: CreateVersionedClients,
+        test_path: Literal["/test"],
+        router: VersionedAPIRouter,
+    ):
+        completed_tasks: list[str] = []
+
+        def record_completed_task(task_name: str) -> None:
+            completed_tasks.append(task_name)
+
+        original_background = BackgroundTask(record_completed_task, "original")
+        migrated_background = BackgroundTask(record_completed_task, "migrated")
+
+        @router.get(test_path)
+        async def endpoint():
+            return JSONResponse({"message": "hello"}, background=original_background)
+
+        @convert_response_to_previous_version_for(test_path, ["GET"])
+        def migrator(response: ResponseInfo):
+            assert response.background is original_background
+            response.background = migrated_background
+            assert response.background is migrated_background
+
+        clients = create_versioned_clients(version_change(migrator=migrator))
+
+        assert clients["2000-01-01"].get(test_path).json() == {"message": "hello"}
+        assert completed_tasks == ["migrated"]
+
+        assert clients["2001-01-01"].get(test_path).json() == {"message": "hello"}
+        assert completed_tasks == ["migrated", "original"]
+
     def test__all_response_components_migration__post_endpoint__migration_filled_results_up(
         self,
         create_versioned_clients: CreateVersionedClients,

--- a/tests/test_data_migrations.py
+++ b/tests/test_data_migrations.py
@@ -611,6 +611,28 @@ class TestResponseMigrations:
         assert set(clients) == {"2000-01-01"}
         assert clients["2000-01-01"].get(test_path, params={"kwargs": "value"}).json() == {"message": "hello"}
 
+    def test__background_tasks_param__does_not_collide_with_user_params(
+        self,
+        create_versioned_clients: CreateVersionedClients,
+        router: VersionedAPIRouter,
+    ):
+        completed_tasks: list[str] = []
+
+        @router.get("/query-param")
+        async def query_param_endpoint(cadwyn_background_tasks_param: str):
+            return cadwyn_background_tasks_param
+
+        @router.get("/background-tasks-param")
+        async def background_tasks_param_endpoint(cadwyn_background_tasks_param: BackgroundTasks):
+            cadwyn_background_tasks_param.add_task(completed_tasks.append, "completed")
+            return {"message": "hello"}
+
+        client = create_versioned_clients()["2000-01-01"]
+
+        assert client.get("/query-param", params={"cadwyn_background_tasks_param": "value"}).json() == "value"
+        assert client.get("/background-tasks-param").json() == {"message": "hello"}
+        assert completed_tasks == ["completed"]
+
     def test__all_response_components_migration__post_endpoint__migration_filled_results_up(
         self,
         create_versioned_clients: CreateVersionedClients,
@@ -1380,6 +1402,33 @@ def test__request_and_response_migrations__for_endpoint_with_http_exception__can
     resp_2001 = clients["2001-01-01"].post("/test")
     assert resp_2001.status_code == 404
     assert resp_2001.json() == {"detail": "Not Found"}
+
+
+def test__request_and_response_migrations__for_http_exception__can_add_background_task(
+    create_versioned_clients: CreateVersionedClients,
+    router: VersionedAPIRouter,
+):
+    completed_tasks: list[str] = []
+
+    @router.post("/test")
+    async def endpoint():
+        raise HTTPException(status_code=400, detail="bad request")
+
+    @convert_response_to_previous_version_for("/test", ["POST"], migrate_http_errors=True)
+    def response_converter(response: ResponseInfo):
+        response.background = BackgroundTask(completed_tasks.append, "migrated")
+
+    clients = create_versioned_clients(version_change(resp=response_converter))
+
+    resp_2000 = clients["2000-01-01"].post("/test")
+    assert resp_2000.status_code == 400
+    assert resp_2000.json() == {"detail": "bad request"}
+    assert completed_tasks == ["migrated"]
+
+    resp_2001 = clients["2001-01-01"].post("/test")
+    assert resp_2001.status_code == 400
+    assert resp_2001.json() == {"detail": "bad request"}
+    assert completed_tasks == ["migrated"]
 
 
 def test__request_and_response_migrations__for_endpoint_with_no_default_status_code__response_should_contain_default(


### PR DESCRIPTION
## Summary

- expose typed `ResponseInfo.media_type` and `ResponseInfo.background` properties without exposing the underlying response
- proxy explicit Starlette response attributes while plumbing background changes into FastAPI's final response for ordinary body returns
- preserve replacement and removal semantics for existing background-task collections
- cover media-type access and background-task behavior through public response migrations
- document the new public migration interfaces and the existing `Content-Type` behavior

Closes #111

## Validation

- `make check` (Python 3.10–3.14 tests and typechecks, tutorial, coverage, lint, docs, links, and build)