### PR TITLE
Improve VersionChange descriptions across the docs

### DIFF
--- a/docs/concepts/changelogs.md
+++ b/docs/concepts/changelogs.md
@@ -11,7 +11,10 @@ from cadwyn import VersionChange, endpoint, hidden
 
 
 class VersionChangeWithOneHiddenInstruction(VersionChange):
-    description = "..."
+    description = (
+        "User lookup routes now use consistent path-parameter names to make "
+        "generated clients easier to use."
+    )
     instructions_to_migrate_to_previous_version = (
         hidden(endpoint("/users/{user_id}", ["GET"]).had(path="/users/{uid}")),
     )
@@ -19,7 +22,10 @@ class VersionChangeWithOneHiddenInstruction(VersionChange):
 
 @hidden
 class CompletelyHiddenVersionChange(VersionChange):
-    description = "..."
+    description = (
+        "The legacy 'User.address' field has been removed because addresses are "
+        "now managed as separate resources."
+    )
     instructions_to_migrate_to_previous_version = (
         schema(User).field("address").existed_as(type=str),
     )

--- a/docs/concepts/endpoint_migrations.md
+++ b/docs/concepts/endpoint_migrations.md
@@ -20,7 +20,10 @@ from cadwyn import VersionChange, endpoint
 
 
 class MyChange(VersionChange):
-    description = "..."
+    description = (
+        "The 'GET /users/{user_id}' endpoint has been removed because user "
+        "profiles are now retrieved through the users collection."
+    )
     instructions_to_migrate_to_previous_version = (
         endpoint("/users/{user_id}", ["GET"]).existed,
     )
@@ -35,7 +38,10 @@ from cadwyn import VersionChange, endpoint
 
 
 class MyChange(VersionChange):
-    description = "..."
+    description = (
+        "Clients can now retrieve an individual company with "
+        "'GET /companies/{company_id}' instead of filtering the company list."
+    )
     instructions_to_migrate_to_previous_version = (
         endpoint("/companies/{company_id}", ["GET"]).didnt_exist,
     )
@@ -50,7 +56,10 @@ from cadwyn import VersionChange, endpoint
 
 
 class MyChange(VersionChange):
-    description = "..."
+    description = (
+        "The 'GET /users/{user_id}' documentation now clarifies the returned "
+        "user data so clients can interpret the response correctly."
+    )
     instructions_to_migrate_to_previous_version = (
         endpoint("/users/{user_id}", ["GET"]).had(
             description="My old description",
@@ -101,8 +110,8 @@ from cadwyn import VersionChange, endpoint
 
 class UseParamsInsteadOfHeadersForUserNameFiltering(VersionChange):
     description = (
-        "Use params instead of headers for user name filtering in 'GET /users' "
-        "because using headers is a poor API practice in such scenarios."
+        "'GET /users' now accepts the user-name filter as a query parameter "
+        "instead of a header, following standard HTTP filtering conventions."
     )
     instructions_to_migrate_to_previous_version = (
         # Specify the name; otherwise you will encounter an exception due to

--- a/docs/concepts/enum_migrations.md
+++ b/docs/concepts/enum_migrations.md
@@ -15,7 +15,10 @@ from cadwyn import VersionChange, enum
 
 
 class MyChange(VersionChange):
-    description = "..."
+    description = (
+        "'foo' and 'bar' are no longer returned in 'my_enum' because those "
+        "legacy states are no longer supported."
+    )
     instructions_to_migrate_to_previous_version = (
         enum(my_enum).had(foo="baz", bar=auto()),
     )
@@ -28,7 +31,10 @@ from cadwyn import VersionChange, enum
 
 
 class MyChange(VersionChange):
-    description = "..."
+    description = (
+        "'my_enum' now includes 'foo' and 'bar' so clients can represent the "
+        "newly supported states."
+    )
     instructions_to_migrate_to_previous_version = (
         enum(my_enum).didnt_have("foo", "bar"),
     )

--- a/docs/concepts/schema_migrations.md
+++ b/docs/concepts/schema_migrations.md
@@ -12,7 +12,10 @@ from pydantic import Field
 
 
 class MyChange(VersionChange):
-    description = "..."
+    description = (
+        "'MySchema.foo' has been removed because clients no longer need the "
+        "legacy list of values."
+    )
     instructions_to_migrate_to_previous_version = (
         schema(MySchema)
         .field("foo")
@@ -27,7 +30,10 @@ from cadwyn import VersionChange, schema
 
 
 class MyChange(VersionChange):
-    description = "..."
+    description = (
+        "'MySchema.foo' is now available so clients can read the value directly "
+        "instead of deriving it from other fields."
+    )
     instructions_to_migrate_to_previous_version = (
         schema(MySchema).field("foo").didnt_exist,
     )
@@ -42,7 +48,10 @@ from cadwyn import VersionChange, schema
 
 
 class MyChange(VersionChange):
-    description = "..."
+    description = (
+        "The documentation for 'MySchema.foo' now explains the field's purpose "
+        "so clients can interpret its value correctly."
+    )
     instructions_to_migrate_to_previous_version = (
         schema(MySchema).field("foo").had(description="Foo"),
     )
@@ -55,7 +64,10 @@ from cadwyn import VersionChange, schema
 
 
 class MyChange(VersionChange):
-    description = "..."
+    description = (
+        "'MySchema.foo' now has a documented meaning so clients do not need to "
+        "infer how to use it."
+    )
     instructions_to_migrate_to_previous_version = (
         schema(MySchema).field("foo").didnt_have("description"),
     )
@@ -92,7 +104,10 @@ def validate_foo(cls, value):
 
 
 class MyChange(VersionChange):
-    description = "..."
+    description = (
+        "'MySchema.foo' no longer requires colon-separated values because the "
+        "field now accepts plain text."
+    )
     instructions_to_migrate_to_previous_version = (
         schema(MySchema).validator(validate_foo).existed,
     )
@@ -106,7 +121,10 @@ from pydantic import Field, validator
 
 
 class MyChange(VersionChange):
-    description = "..."
+    description = (
+        "'MySchema.foo' must now contain a colon to distinguish the value's two "
+        "components."
+    )
     instructions_to_migrate_to_previous_version = (
         schema(MySchema).validator(MySchema.validate_foo).didnt_exist,
     )
@@ -122,7 +140,10 @@ from cadwyn import VersionChange, schema
 
 
 class MyChange(VersionChange):
-    description = "..."
+    description = (
+        "'OtherSchema' has been renamed to 'MySchema' to match the resource name "
+        "used throughout the API."
+    )
     instructions_to_migrate_to_previous_version = (
         schema(MySchema).had(name="OtherSchema"),
     )

--- a/docs/concepts/version_changes.md
+++ b/docs/concepts/version_changes.md
@@ -20,7 +20,10 @@ from cadwyn import VersionChange, endpoint
 
 
 class RemoveTaxIdEndpoints(VersionChange):
-    description = "Remove 'GET /v1/tax_ids' and 'POST /v1/tax_ids' endpoints"
+    description = (
+        "The 'GET /v1/tax_ids' and 'POST /v1/tax_ids' endpoints have been "
+        "removed because tax IDs are now managed on customer records."
+    )
     instructions_to_migrate_to_previous_version = (
         endpoint("/v1/tax_ids", ["GET", "POST"]).existed,
     )
@@ -151,7 +154,10 @@ from invoices import InvoiceCreateRequest
 
 
 class RemoveTaxIdEndpoints(VersionChange):
-    description = "Rename 'Invoice.creation_date' to 'Invoice.created_at'."
+    description = (
+        "Invoice creation timestamps are now returned as 'created_at' instead of "
+        "'creation_date' to align with the API's other timestamp fields."
+    )
     instructions_to_migrate_to_previous_version = (
         schema(InvoiceCreateRequest)
         .field("creation_date")
@@ -186,7 +192,10 @@ from invoices import (
 
 
 class RemoveTaxIdEndpoints(VersionChange):
-    description = "Rename 'Invoice.creation_date' to 'Invoice.created_at'."
+    description = (
+        "Invoice creation timestamps are now returned as 'created_at' instead of "
+        "'creation_date' to align with the API's other timestamp fields."
+    )
     instructions_to_migrate_to_previous_version = (
         schema(BaseInvoice).field("creation_date").had(name="created_at"),
     )
@@ -225,7 +234,10 @@ from invoices import BaseInvoice
 
 
 class RemoveTaxIdEndpoints(VersionChange):
-    description = "Rename 'Invoice.creation_date' to 'Invoice.created_at'."
+    description = (
+        "Invoice creation timestamps are now returned as 'created_at' instead of "
+        "'creation_date' to align with the API's other timestamp fields."
+    )
     instructions_to_migrate_to_previous_version = (
         schema(BaseInvoice).field("creation_date").had(name="created_at"),
     )
@@ -256,7 +268,10 @@ from cadwyn import (
 
 
 class RemoveTaxIdEndpoints(VersionChange):
-    description = "Replace status code 400 with 404 in 'GET /v1/invoices' if invoice is not found"
+    description = (
+        "Missing invoices from 'GET /v1/invoices' now return 404 instead of 400 "
+        "so clients can distinguish absent resources from invalid requests."
+    )
     instructions_to_migrate_to_previous_version = ()
 
     @convert_response_to_previous_version_for(
@@ -306,7 +321,10 @@ from users import BaseUser
 
 # THIS IS AN EXAMPLE OF A POOR MIGRATION
 class RemoveTaxIdEndpoints(VersionChange):
-    description = "Users now have 'address' field instead of 'addresses'"
+    description = (
+        "Users now expose a single 'address' instead of 'addresses' because only "
+        "one mailing address is supported."
+    )
     instructions_to_migrate_to_previous_version = (
         schema(BaseUser).field("address").didnt_exist,
         schema(BaseUser).field("addresses").existed_as(type=list[str]),
@@ -346,7 +364,10 @@ from users import User
 
 
 class RemoveTaxIdEndpoints(VersionChange):
-    description = "Users now have 'address' field instead of 'addresses'"
+    description = (
+        "Users now expose a single 'address' instead of 'addresses' because only "
+        "one mailing address is supported."
+    )
     instructions_to_migrate_to_previous_version = (
         schema(User).field("address").didnt_exist,
         schema(User).field("addresses").existed_as(type=list[str]),
@@ -456,8 +477,8 @@ from cadwyn import VersionChangeWithSideEffects
 
 class UserAddressIsCheckedInExternalService(VersionChangeWithSideEffects):
     description = (
-        "User's address is now checked against existence in an external service. "
-        "If it is not found, a 400 code is returned."
+        "User addresses are now verified by an external service during creation; "
+        "invalid addresses return 400 to prevent storing undeliverable locations."
     )
 ```
 

--- a/docs/how_to/change_openapi_schemas/add_field.md
+++ b/docs/how_to/change_openapi_schemas/add_field.md
@@ -35,7 +35,10 @@ Let's say that our users had a field `country` that defaulted to `USA` but our p
 
 
     class MakeUserCountryRequired(VersionChange):
-        description = 'Make user country required instead of the "USA" default'
+        description = (
+            "'country' is now required when creating a user because the API "
+            "serves users outside the United States and can no longer assume 'USA'."
+        )
         instructions_to_migrate_to_previous_version = (
             schema(UserCreateRequest).field("country").had(default="USA"),
         )
@@ -78,8 +81,8 @@ So we will make `phone` nullable in HEAD, then make it required in `latest`, and
 
     class MakePhoneNonNullableInLatest(VersionChange):
         description = (
-            "Make sure the phone is nullable in the HEAD version to support "
-            "versions older than 2001_01_01 where it became non-nullable"
+            "New user requests now require a phone number so accounts can support "
+            "SMS verification and two-factor authentication."
         )
         instructions_to_migrate_to_previous_version = (
             schema(UserCreateRequest).field("phone").had(type=str),
@@ -92,8 +95,8 @@ So we will make `phone` nullable in HEAD, then make it required in `latest`, and
     ```python
     class AddPhoneToUser(VersionChange):
         description = (
-            "Add a required phone field to User to allow us to do 2fa and to "
-            "make it possible to verify new user accounts using an sms."
+            "New user requests now require a phone number so accounts can support "
+            "SMS verification and two-factor authentication."
         )
         instructions_to_migrate_to_previous_version = (
             schema(UserCreateRequest)

--- a/docs/how_to/change_openapi_schemas/change_field_type.md
+++ b/docs/how_to/change_openapi_schemas/change_field_type.md
@@ -25,9 +25,8 @@ This is not a breaking change in terms of requests but it [**can be**](#why-enum
 
     class AddModeratorRoleToUser(VersionChange):
         description = (
-            "Add 'moderator' role to users that represents an admin "
-            "that cannot create or remove other admins. This provides "
-            "finer-grained control over permissions."
+            "Users can now have a 'moderator' role with administrative access but "
+            "without permission to create or remove admins, enabling safer delegation."
         )
         instructions_to_migrate_to_previous_version = (
             enum(UserRoleEnum).didnt_have("moderator"),
@@ -81,8 +80,8 @@ Suppose that previously users could specify their date of birth as a datetime in
 
     class ChangeDateOfBirthToDateInUserInLatest(VersionChange):
         description = (
-            "Change 'BaseUser.date_of_birth' field type to datetime in HEAD "
-            "to support versions and data before 2001-01-01. "
+            "'User.date_of_birth' is now a calendar date instead of a timestamp "
+            "because a time of day is not meaningful for a birth date."
         )
         instructions_to_migrate_to_previous_version = (
             schema(BaseUser).field("date_of_birth").had(type=datetime.date),
@@ -97,8 +96,8 @@ Suppose that previously users could specify their date of birth as a datetime in
     ```python
     class ChangeDateOfBirthToDateInUser(VersionChange):
         description = (
-            "Change 'User.date_of_birth' field type to date instead of "
-            "a datetime because storing the exact time is unnecessary."
+            "'User.date_of_birth' is now a calendar date instead of a timestamp "
+            "because a time of day is not meaningful for a birth date."
         )
         instructions_to_migrate_to_previous_version = (
             schema(BaseUser).field("date_of_birth").had(type=datetime.datetime),

--- a/docs/how_to/change_openapi_schemas/changing_constraints.md
+++ b/docs/how_to/change_openapi_schemas/changing_constraints.md
@@ -13,9 +13,8 @@ Suppose you previously allowed users to have a name of arbitrary length but now 
 
     class AddLengthConstraintToNameInLatest(VersionChange):
         description = (
-            "Remove the 'max_length' constraint from the HEAD version to "
-            "support versions older than 2001_01_01 where the constraint "
-            "did not exist."
+            "User names in creation requests are now limited to 250 characters "
+            "to prevent impractically large values."
         )
         instructions_to_migrate_to_previous_version = (
             schema(UserCreateRequest).field("name").had(max_length=250),
@@ -27,8 +26,8 @@ Suppose you previously allowed users to have a name of arbitrary length but now 
     ```python
     class AddMaxLengthConstraintToUserNames(VersionChange):
         description = (
-            "Add a max length of 250 to user names when creating new "
-            "users to prevent excessively large names from being used."
+            "User names in creation requests are now limited to 250 characters "
+            "to prevent impractically large values."
         )
         instructions_to_migrate_to_previous_version = (
             schema(UserCreateRequest).field("name").didnt_have("max_length"),

--- a/docs/how_to/change_openapi_schemas/remove_field.md
+++ b/docs/how_to/change_openapi_schemas/remove_field.md
@@ -15,9 +15,8 @@ Let's say that our API has a mandatory `UserResource.date_of_birth` field. Let's
 
     class RemoveZodiacSignFromUser(VersionChange):
         description = (
-            "Remove 'zodiac_sign' field from UserResource because "
-            "it can be inferred from user's date of birth and because "
-            "only a small number of users has utilized it."
+            "User responses no longer include 'zodiac_sign' because it can be "
+            "derived from 'date_of_birth' and is rarely used."
         )
         instructions_to_migrate_to_previous_version = (
             schema(UserResource)
@@ -62,8 +61,8 @@ Let's say that we had a nullable `middle_name` field but we decided that it does
 
     class RemoveMiddleNameFromLatestVersion(VersionChange):
         description = (
-            "Remove 'User.middle_name' from latest but keep it in HEAD "
-            "to support versions before 2001-01-01."
+            "User requests and responses no longer include 'middle_name' because "
+            "the product no longer uses it."
         )
         instructions_to_migrate_to_previous_version = (
             schema(BaseUser).field("middle_name").didnt_exist,
@@ -78,7 +77,10 @@ Let's say that we had a nullable `middle_name` field but we decided that it does
 
 
     class RemoveMiddleNameFromUser(VersionChange):
-        description = "Remove 'User.middle_name' field"
+        description = (
+            "User requests and responses no longer include 'middle_name' because "
+            "the product no longer uses it."
+        )
         instructions_to_migrate_to_previous_version = (
             schema(BaseUser)
             .field("middle_name")

--- a/docs/how_to/change_openapi_schemas/rename_a_field_in_schema.md
+++ b/docs/how_to/change_openapi_schemas/rename_a_field_in_schema.md
@@ -19,7 +19,8 @@ Assume you had a `summary` field before but now you want to rename it to `bio`.
 
     class RenameSummaryToBioInUser(VersionChange):
         description = (
-            "Rename 'summary' field to 'bio' to keep up with industry standards"
+            "The user profile field 'summary' is now named 'bio' to match familiar "
+            "profile terminology."
         )
         instructions_to_migrate_to_previous_version = (
             schema(BaseUser).field("bio").had(name="summary"),

--- a/docs_src/how_to/change_openapi_schemas/change_schema_without_endpoint/block001.py
+++ b/docs_src/how_to/change_openapi_schemas/change_schema_without_endpoint/block001.py
@@ -15,9 +15,8 @@ class User(BaseModel):
 
 class ChangeUserIDToString(VersionChange):
     description = (
-        "Change users' ID field to a string to support any kind of ID. "
-        "Be careful: if you use a non-integer ID in a new version and "
-        "try to get it from the old version, the ID will be zero in response"
+        "'User.id' is now a string so the API can support identifiers that are "
+        "not numeric."
     )
     instructions_to_migrate_to_previous_version = [
         schema(User).field("id").had(type=int),

--- a/docs_src/how_to/change_openapi_schemas/change_schema_without_endpoint/block002.py
+++ b/docs_src/how_to/change_openapi_schemas/change_schema_without_endpoint/block002.py
@@ -15,9 +15,8 @@ class User(BaseModel):
 
 class ChangeUserIDToString(VersionChange):
     description = (
-        "Change users' ID field to a string to support any kind of ID. "
-        "Be careful: if you use a non-integer ID in a new version and "
-        "try to get it from the old version, the ID will be zero in response"
+        "'User.id' is now a string so the API can support identifiers that are "
+        "not numeric."
     )
     instructions_to_migrate_to_previous_version = [
         schema(User).field("id").had(type=int),

--- a/docs_src/how_to/version_with_path_and_numbers_instead_of_headers_and_dates/block001.py
+++ b/docs_src/how_to/version_with_path_and_numbers_instead_of_headers_and_dates/block001.py
@@ -40,7 +40,10 @@ class UserAddressResourceList(BaseModel):
 
 
 class ChangeAddressToList(VersionChange):
-    description = "Change vat id to list"
+    description = (
+        "Users can now store multiple addresses instead of a single address so "
+        "they can choose among delivery locations."
+    )
     instructions_to_migrate_to_previous_version = (
         schema(BaseUser).field("addresses").didnt_exist,
         schema(BaseUser).field("address").existed_as(type=str, info=Field()),
@@ -57,7 +60,10 @@ class ChangeAddressToList(VersionChange):
 
 
 class ChangeAddressesToSubresource(VersionChange):
-    description = "Change vat ids to subresource"
+    description = (
+        "User addresses are now separate resources with stable IDs, allowing "
+        "clients to retrieve each address independently."
+    )
     instructions_to_migrate_to_previous_version = (
         schema(BaseUser)
         .field("addresses")
@@ -83,8 +89,8 @@ class ChangeAddressesToSubresource(VersionChange):
 
 class RemoveAddressesToCreateFromLatest(VersionChange):
     description = (
-        "In order to support old versions, we gotta have `addresses_to_create` "
-        "located in head schemas but we do not need this field in latest schemas."
+        "'addresses_to_create' is no longer accepted when creating users because "
+        "additional addresses are now managed as separate resources."
     )
     instructions_to_migrate_to_previous_version = (
         schema(UserCreateRequest).field("addresses_to_create").didnt_exist,

--- a/docs_src/quickstart/tutorial/block003.py
+++ b/docs_src/quickstart/tutorial/block003.py
@@ -43,7 +43,8 @@ async def get_user(user_id: uuid.UUID) -> UserResource:
 
 class ChangeAddressToList(VersionChange):
     description = (
-        "Give user the ability to have multiple addresses at the same time"
+        "Users can now store multiple addresses instead of a single address so "
+        "they can choose among delivery locations."
     )
     instructions_to_migrate_to_previous_version = (
         schema(UserCreateRequest)

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -47,14 +47,20 @@ def test__changelog__with_multiple_versions():
         data: list[UserAddressResource]
 
     class ChangeAddressToList(VersionChange):
-        description = "Change vat id to list"
+        description = (
+            "Users can now store multiple addresses instead of a single address so "
+            "they can choose among delivery locations."
+        )
         instructions_to_migrate_to_previous_version = (
             schema(BaseUser).field("addresses").didnt_exist,
             schema(BaseUser).field("address").existed_as(type=str, info=Field()),
         )
 
     class ChangeAddressesToSubresource(VersionChange):
-        description = "Change vat ids to subresource"
+        description = (
+            "User addresses are now separate resources with stable IDs, allowing "
+            "clients to retrieve each address independently."
+        )
         instructions_to_migrate_to_previous_version = (
             schema(BaseUser).field("addresses").existed_as(type=list[str], info=Field()),
             schema(UserCreateRequest).field("default_address").didnt_exist,
@@ -62,7 +68,10 @@ def test__changelog__with_multiple_versions():
         )
 
     class RemoveAddressesToCreateFromLatest(VersionChange):
-        description = "..."
+        description = (
+            "'addresses_to_create' is no longer accepted when creating users because "
+            "additional addresses are now managed as separate resources."
+        )
         instructions_to_migrate_to_previous_version = (
             schema(UserCreateRequest).field("addresses_to_create").didnt_exist,
         )
@@ -103,7 +112,10 @@ def test__changelog__with_multiple_versions():
                 "value": "2002-01-01",
                 "changes": [
                     {
-                        "description": "Change vat ids to subresource",
+                        "description": (
+                            "User addresses are now separate resources with stable IDs, allowing "
+                            "clients to retrieve each address independently."
+                        ),
                         "side_effects": False,
                         "instructions": [
                             {
@@ -130,7 +142,10 @@ def test__changelog__with_multiple_versions():
                 "value": "2001-01-01",
                 "changes": [
                     {
-                        "description": "Change vat id to list",
+                        "description": (
+                            "Users can now store multiple addresses instead of a single address so "
+                            "they can choose among delivery locations."
+                        ),
                         "side_effects": False,
                         "instructions": [
                             {

--- a/tests/tutorial/main.py
+++ b/tests/tutorial/main.py
@@ -42,7 +42,10 @@ class UserAddressResourceList(BaseModel):
 
 
 class ChangeAddressToList(VersionChange):
-    description = "Change vat id to list"
+    description = (
+        "Users can now store multiple addresses instead of a single address so "
+        "they can choose among delivery locations."
+    )
     instructions_to_migrate_to_previous_version = (
         schema(BaseUser).field("addresses").didnt_exist,
         schema(BaseUser).field("address").existed_as(type=str, info=Field()),
@@ -59,7 +62,10 @@ class ChangeAddressToList(VersionChange):
 
 
 class ChangeAddressesToSubresource(VersionChange):
-    description = "Change vat ids to subresource"
+    description = (
+        "User addresses are now separate resources with stable IDs, allowing "
+        "clients to retrieve each address independently."
+    )
     instructions_to_migrate_to_previous_version = (
         schema(BaseUser).field("addresses").existed_as(type=list[str], info=Field()),
         schema(UserCreateRequest).field("default_address").didnt_exist,
@@ -79,8 +85,8 @@ class ChangeAddressesToSubresource(VersionChange):
 
 class RemoveAddressesToCreateFromLatest(VersionChange):
     description = (
-        "In order to support old versions, we gotta have `addresses_to_create` located in "
-        "head schemas but we do not need this field in latest schemas."
+        "'addresses_to_create' is no longer accepted when creating users because "
+        "additional addresses are now managed as separate resources."
     )
     instructions_to_migrate_to_previous_version = (schema(UserCreateRequest).field("addresses_to_create").didnt_exist,)
 


### PR DESCRIPTION
## Summary

- replace empty, placeholder, underspecified, and overly implementation-focused `VersionChange.description` examples with concise client-facing explanations
- keep executable `docs_src` snippets, the advanced tutorial, and changelog expectations consistent with the rendered docs
- leave `VersionChange` class names unchanged so the separate #110 work remains out of scope

## Why

The documentation taught that descriptions should tell clients what changed and why, but many reader-facing examples did not follow that guidance. This made the examples poor models for real changelog entries.

## Validation

- `uv run tox run`
  - 379 tests passed on each of Python 3.10, 3.11, 3.12, 3.13, and 3.14
  - executable docs tests passed
  - strict MkDocs build passed
  - link validation passed
  - lint passed
  - package build passed
  - combined coverage remained 100%

Closes #109