### PR TITLE
Clarify test naming and organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Please follow [the Keep a Changelog standard](https://keepachangelog.com/en/1.0.
 ### Changed
 
 - Simplified contributor setup and development commands (#387)
+- Standardized test names around the `what`, `when`, and `expected` convention and documented test organization (#397)
 
 ## [7.1.1]
 

--- a/docs/home/CONTRIBUTING.md
+++ b/docs/home/CONTRIBUTING.md
@@ -58,6 +58,17 @@ early and print the matching `uv tool install ...` command to install it.
 Use `make lint` to run only the prek hooks. For a focused test run, use
 `uv run pytest` followed by the test path and any pytest options.
 
+Name tests after the behavior they exercise, the relevant context, and the
+observable outcome:
+
+`test__{behavior}__{context}__should_{outcome}`
+
+The context or outcome may be omitted when it is already obvious from the
+behavior. Prefer concrete outcomes such as `should_return_404` or
+`should_raise_router_generation_error` over generic suffixes such as `error`,
+`ok`, or numbered variants. Test names should let a reader understand a failed
+test without first opening its implementation.
+
 ### Running type checkers
 
 We use [ty](https://github.com/astral-sh/ty) to enforce type safety.

--- a/docs/home/CONTRIBUTING.md
+++ b/docs/home/CONTRIBUTING.md
@@ -43,9 +43,13 @@ setting. You can still run every hook manually with `make lint`.
 ### Writing and running tests
 
 Tests are contained within the `tests` directory, and follow roughly the same
-directory structure as the `cadwyn` module. If you are adding a test
-case, it should be located within the correct submodule of `tests`. E.g.
-tests for `cadwyn/codegen.py` reside in `tests/codegen`.
+directory structure as the `cadwyn` module. Place each test according to the
+public interface it exercises. If a test has no natural location in that
+structure, check whether it is testing an internal implementation detail that
+would be better covered through a public interface.
+
+Keep tests atomic. Separate distinct positive and negative scenarios, and use
+parametrization when the same behavior needs to be checked with several inputs.
 
 `make check` runs the local CI-equivalent suite with tox's default automatic
 parallelism. It runs the supported Python test matrix, tutorial tests, coverage,
@@ -58,16 +62,16 @@ early and print the matching `uv tool install ...` command to install it.
 Use `make lint` to run only the prek hooks. For a focused test run, use
 `uv run pytest` followed by the test path and any pytest options.
 
-Name tests after the behavior they exercise, the relevant context, and the
-observable outcome:
+Name tests using the `what`, `when`, `expected` convention:
 
-`test__{behavior}__{context}__should_{outcome}`
+`test__{what}__{when}__{expected}`
 
-The context or outcome may be omitted when it is already obvious from the
-behavior. Prefer concrete outcomes such as `should_return_404` or
+`what` is the function or public interface under test, `when` describes the
+conditions in which it is exercised, and `expected` states the observable
+result. Prefer concrete outcomes such as `should_return_404` or
 `should_raise_router_generation_error` over generic suffixes such as `error`,
-`ok`, or numbered variants. Test names should let a reader understand a failed
-test without first opening its implementation.
+`ok`, or numbered variants. A test name should let a reader understand a
+failure without first opening its implementation.
 
 ### Running type checkers
 

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from fastapi.routing import APIRoute
 
 
-def test__header_routing__invalid_version_format__error():
+def test__header_routing__invalid_version_format__should_raise_value_error():
     main_app = Cadwyn(versions=VersionBundle(Version("2022-11-16")))
     with pytest.warns(DeprecationWarning):
         main_app.add_header_versioned_routers(  # ty: ignore[deprecated]  # This test verifies the legacy API.
@@ -404,7 +404,7 @@ def test__get_openapi():
     assert resp.status_code == 200
 
 
-def test__get_openapi__nonexisting_version__error():
+def test__get_openapi__nonexisting_version__should_return_404():
     resp = client_without_headers.get("/openapi.json?version=2023-01-01")
     assert resp.status_code == 404
     assert resp.json() == {"detail": "OpenApi file of with version `2023-01-01` not found"}

--- a/tests/test_data_migrations.py
+++ b/tests/test_data_migrations.py
@@ -742,7 +742,7 @@ class TestHowAndWhenMigrationsApply:
         )
 
     # TODO: An error is a better behavior here
-    def test__try_migrating_to_version_below_earliest__undefined_behaior(
+    def test__try_migrating_to_version_below_earliest__should_apply_all_migrations(
         self,
         create_versioned_clients: CreateVersionedClients,
         version_change_1: type[VersionChange],

--- a/tests/test_router_generation.py
+++ b/tests/test_router_generation.py
@@ -586,7 +586,7 @@ def test__endpoint_had_dependencies(
     assert len(routes_2001[1].dependencies) == 1
 
 
-def test__only_exists_in_older_versions__endpoint_is_not_a_route__error(
+def test__only_exists_in_older_versions__endpoint_is_not_a_route__should_raise_lookup_error(
     router: VersionedAPIRouter,
     test_endpoint: Endpoint,
 ):
@@ -639,7 +639,7 @@ def test__only_exists_in_older_versions__applied_twice__should_raise_error(
             raise NotImplementedError
 
 
-def test__router_generation__changing_a_deleted_endpoint__error(
+def test__router_generation__changing_a_deleted_endpoint__should_raise_router_generation_error(
     router: VersionedAPIRouter,
     create_versioned_app: CreateVersionedApp,
 ):
@@ -657,7 +657,7 @@ def test__router_generation__changing_a_deleted_endpoint__error(
         create_versioned_app(version_change(endpoint("/test", ["GET"]).had(description="Hewwo")))
 
 
-def test__router_generation__changing_a_non_existent_endpoint__error(
+def test__router_generation__changing_a_non_existent_endpoint__should_raise_router_generation_error(
     router: VersionedAPIRouter,
     create_versioned_app: CreateVersionedApp,
 ):
@@ -670,7 +670,7 @@ def test__router_generation__changing_a_non_existent_endpoint__error(
         create_versioned_app(version_change(endpoint("/test", ["GET"]).had(dependencies=[])))
 
 
-def test__router_generation__re_creating_an_existing_endpoint__error(
+def test__router_generation__re_creating_an_existing_endpoint__should_raise_router_generation_error(
     test_endpoint: Endpoint,
     test_path: str,
     create_versioned_app: CreateVersionedApp,
@@ -766,7 +766,7 @@ def test__router_generation__editing_multiple_methods_of_multiple_endpoints__sho
     assert routes_2001[2].description == ""
 
 
-def test__router_generation__deleting_a_deleted_endpoint__error(
+def test__router_generation__deleting_a_deleted_endpoint__should_raise_router_generation_error(
     router: VersionedAPIRouter,
     create_versioned_app: CreateVersionedApp,
 ):
@@ -959,7 +959,7 @@ def get_nested_field_type(annotation: Any) -> Union[type[BaseModel], None]:
     return annotation_of_its_foo_field.model_fields["foo"].annotation
 
 
-def test__router_generation__re_creating_a_non_endpoint__error(
+def test__router_generation__re_creating_a_non_endpoint__should_raise_router_generation_error(
     create_versioned_app: CreateVersionedApp,
 ):
     with pytest.raises(
@@ -971,7 +971,7 @@ def test__router_generation__re_creating_a_non_endpoint__error(
         create_versioned_app(version_change(endpoint("/test", ["GET"]).existed))
 
 
-def test__router_generation__changing_attribute_to_the_same_value__error(
+def test__router_generation__changing_attribute_to_the_same_value__should_raise_router_generation_error(
     test_endpoint: Endpoint,
     test_path: str,
     create_versioned_app: CreateVersionedApp,

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 
-def test__populate_routes__should_combine_unversioned_and_versioned_routes():
+def test__populate_routes__with_versioned_and_unversioned_routes__should_combine_both_route_sets():
     versioned_routes = [
         route for router in mixed_hosts_app.router.versioned_routers.values() for route in router.routes
     ]
@@ -25,7 +25,7 @@ def test__populate_routes__should_combine_unversioned_and_versioned_routes():
     )
 
 
-def test__header_routing__should_select_requested_or_closest_earlier_version():
+def test__header_routing__with_defined_and_compatible_versions__should_select_requested_or_closest_earlier_version():
     client = TestClient(mixed_hosts_app, headers={"X-API-VERSION": "2022-02-11"})
 
     response = client.get("/v1/users/tom/83")
@@ -122,7 +122,7 @@ def test__url_path_for__parameters_for_child_route_passed_to_mount__should_raise
         mixed_hosts_app.url_path_for("api", path="hellow", username="tom")
 
 
-def test__lifespan__should_run_async_startup_and_shutdown_handlers():
+def test__lifespan__with_async_startup_and_shutdown_handlers__should_run_each_handler():
     startup_complete = False
     shutdown_complete = False
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 
-def test__populate_routes():
+def test__populate_routes__should_combine_unversioned_and_versioned_routes():
     versioned_routes = [
         route for router in mixed_hosts_app.router.versioned_routers.values() for route in router.routes
     ]
@@ -25,7 +25,7 @@ def test__populate_routes():
     )
 
 
-def test__header_routing():
+def test__header_routing__should_select_requested_or_closest_earlier_version():
     client = TestClient(mixed_hosts_app, headers={"X-API-VERSION": "2022-02-11"})
 
     response = client.get("/v1/users/tom/83")
@@ -62,7 +62,7 @@ def test__header_routing():
 
 
 @pytest.mark.parametrize("version", ["2022-04-19", "2022-05-01", "2025-11-12"])
-def test__host_routing__backward__ok(version: str):
+def test__header_routing__version_after_route_introduction__should_use_closest_earlier_route(version: str):
     client = TestClient(mixed_hosts_app, headers={"X-API-VERSION": version})
 
     response = client.get("/v1/doggies/tom")
@@ -70,18 +70,18 @@ def test__host_routing__backward__ok(version: str):
     assert response.json() == {"doggies": [{"dogname": "tom"}]}
 
 
-def test__host_routing__lowest_version__404():
+def test__header_routing__version_before_route_introduction__should_return_404():
     client = TestClient(mixed_hosts_app, headers={"X-API-VERSION": "1993-11-15"})
 
     response = client.get("/v1/doggies/tom")
     assert response.status_code == 404
 
 
-def test__host_routing__non_http():
+def test__header_routing__websocket_scope__should_not_match():
     assert mixed_hosts_app.routes[-1].matches({"type": "websocket", "path": "/v1/"}) == (Match.NONE, {})
 
 
-def test__host_routing__non_date_api_version_header__not_valid_format():
+def test__header_routing__invalid_date_header__should_return_422():
     client = TestClient(mixed_hosts_app, headers={"X-API-VERSION": "2025-40-01"})
 
     response = client.get("/v1/users")
@@ -99,14 +99,14 @@ def test__host_routing__non_date_api_version_header__not_valid_format():
     }
 
 
-def test__host_routing__partial_match__error():
+def test__header_routing__path_match_with_wrong_method__should_return_405():
     client = TestClient(mixed_hosts_app, headers={"X-API-VERSION": "2022-02-11"})
 
     response = client.post("/v1/users/tom/83")
     assert response.status_code == 405
 
 
-def test__url_path_for__not_enough_params__error():
+def test__url_path_for__missing_path_parameter__should_raise_no_match_found():
     with pytest.raises(
         NoMatchFound,
         match='No route exists for name "api:users" and params "username".',
@@ -114,7 +114,7 @@ def test__url_path_for__not_enough_params__error():
         mixed_hosts_app.url_path_for("api:users", username="tom")
 
 
-def test__url_path_for__not_enough_params__error2():
+def test__url_path_for__parameters_for_child_route_passed_to_mount__should_raise_no_match_found():
     with pytest.raises(
         NoMatchFound,
         match='No route exists for name "api" and params "path, username".',
@@ -122,7 +122,7 @@ def test__url_path_for__not_enough_params__error2():
         mixed_hosts_app.url_path_for("api", path="hellow", username="tom")
 
 
-def test__lifespan_async():
+def test__lifespan__should_run_async_startup_and_shutdown_handlers():
     startup_complete = False
     shutdown_complete = False
 
@@ -154,7 +154,7 @@ def test__lifespan_async():
     assert shutdown_complete
 
 
-def test__host_routing__partial_match__404():
+def test__header_routing__exact_oldest_version__should_route_successfully():
     client = TestClient(mixed_hosts_app, headers={"X-API-VERSION": "1998-11-16"})
 
     response = client.get("/v1/doggies/tom")
@@ -166,7 +166,9 @@ async def get_default_version(req: Request):
 
 
 @pytest.mark.parametrize("default_version", ["2023-04-14", get_default_version])
-def test__get_unversioned_endpoints__with_default_version(default_version: "str | Callable"):
+def test__default_version__unversioned_route__should_take_priority_over_versioned_route(
+    default_version: "str | Callable",
+):
     app = Cadwyn(
         versions=VersionBundle(HeadVersion(), Version("2023-04-14"), Version("2022-11-16")),
         api_version_default_value=default_version,

--- a/tests/test_schema_generation/test_enum.py
+++ b/tests/test_schema_generation/test_enum.py
@@ -79,7 +79,7 @@ def test__enum_had__original_schema_is_empty(create_runtime_schemas: CreateRunti
     assert serialize_enum(models["2000-01-01"][EmptyEnum]) == {"b": 7}
 
 
-def test__enum_had__same_name_as_other_value__error(
+def test__enum_had__same_name_as_other_value__should_raise_invalid_generation_instruction_error(
     create_runtime_schemas: CreateRuntimeSchemas,
 ):
     with pytest.raises(
@@ -92,7 +92,7 @@ def test__enum_had__same_name_as_other_value__error(
         create_runtime_schemas(version_change(enum(EnumWithOneMember).had(foo=83)))
 
 
-def test__enum_didnt_have__nonexisting_name__error(
+def test__enum_didnt_have__nonexisting_name__should_raise_invalid_generation_instruction_error(
     create_runtime_schemas: CreateRuntimeSchemas,
 ):
     with pytest.raises(


### PR DESCRIPTION
## Summary

- document Cadwyn's `test__{what}__{when}__{expected}` naming convention
- define `what` as the tested public entrypoint, `when` as the execution conditions, and `expected` as the observable result
- document atomic tests, parametrization instead of loops, and placement by the public interface under test
- rename ambiguous tests so their node IDs follow that convention
- replace vague suffixes such as `error`, `ok`, and numbered variants across representative test modules
- correct the misspelled and non-descriptive below-earliest-version migration test name
- add an Unreleased changelog entry

## Why

Issue #165 identified inconsistent test names and structure, especially in older routing coverage. A failing test should communicate what behavior regressed without requiring contributors to open the test body first.

This is a test-organization and contributor-documentation change only; it does not alter runtime behavior or test assertions.

## Validation

- `uv run --frozen pytest -q tests/test_routing.py tests/test_applications.py tests/test_router_generation.py tests/test_data_migrations.py tests/test_schema_generation/test_enum.py` — 215 passed
- `make check`
- commit hooks

Closes #165