### PR TITLE
Support FastAPI 0.140 in security dependency tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Please follow [the Keep a Changelog standard](https://keepachangelog.com/en/1.0.
 
 ### Changed
 
+- Added FastAPI 0.140 compatibility coverage for security dependencies (#400)
 - Simplified contributor setup and development commands (#387)
 - Standardized test names around the `what`, `when`, and `expected` convention and documented test organization (#397)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ Please follow [the Keep a Changelog standard](https://keepachangelog.com/en/1.0.
 
 ### Changed
 
-- Added FastAPI 0.140 compatibility coverage for security dependencies (#400)
 - Simplified contributor setup and development commands (#387)
 - Standardized test names around the `what`, `when`, and `expected` convention and documented test organization (#397)
 

--- a/tests/test_router_generation.py
+++ b/tests/test_router_generation.py
@@ -1564,7 +1564,7 @@ def test__basic_router_generation__using_http_security_dependency__should_genera
     client_2000, *_ = create_versioned_clients().values()
 
     dependant = cast("APIRoute", client_2000.app.router.versioned_routers["2000-01-01"].routes[-1]).dependant
-    assert dependant.dependencies[1].dependencies[0]._security_scheme is auth_header_scheme
+    assert dependant.dependencies[1].dependencies[0].call is auth_header_scheme
     response = client_2000.get("/test")
     assert response.status_code == expected_status_code
     assert response.json() == {"detail": "Not authenticated"}

--- a/uv.lock
+++ b/uv.lock
@@ -527,7 +527,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.139.2"
+version = "0.140.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -536,9 +536,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cd/95/d3f0ae10836324a2eab98a52b61210ac609f08200bf4bb0dc8132d32f78a/fastapi-0.139.2.tar.gz", hash = "sha256:333145a6891e9b5b3cfceb69baf817e8240cde4d4588ae5a10bf56ffacb6255e", size = 423428, upload-time = "2026-07-16T15:06:17.912Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/fb/fd7671137d9fa3df1d93a2f5111eb982709201724b29f211e4beb2d58688/fastapi-0.140.0.tar.gz", hash = "sha256:f338951b82fd74ca8f843163aec43ea1a1ce84d515415a50fa98fa25572a5544", size = 420968, upload-time = "2026-07-24T21:16:41.187Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/c7/cb03251d9dfb177246a9809a76f189d21df32dbd4a845951881d11323b7f/fastapi-0.139.2-py3-none-any.whl", hash = "sha256:b9ad015a835173d59865e2f5d8296fbc2b317bf56a2ba1a5bfbdd03de2fd4b1c", size = 130234, upload-time = "2026-07-16T15:06:19.557Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/76/6d9e25ad88da9d3ff744bcdbec4736e38c2288611d43f673a5d9bfa27c07/fastapi-0.140.0-py3-none-any.whl", hash = "sha256:e951c0a0d9540bf5d9a2a9e078fd415da2ab7e312d435139e7d9e2e7fe9f0b23", size = 130863, upload-time = "2026-07-24T21:16:42.89Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## What changed

- update the security-dependency regression test to verify the preserved scheme through `Dependant.call`
- refresh the lockfile to FastAPI 0.140.0 so normal PR CI covers the new release

## Why

FastAPI 0.140.0 made `Dependant` slotted to reduce dependency-graph memory usage and removed the private cached `_security_scheme` property. Cadwyn’s twice-daily dependency-refresh workflow therefore failed during `ty` before tests ran, even though the security dependency behavior still works.

The replacement assertion keeps the original object-identity guarantee without depending on the removed private FastAPI property.

## Validation

- reproduced the linked Python 3.12 `ty` failure with FastAPI 0.140.0
- targeted security-dependency test passed with FastAPI 0.139.2 and 0.140.0
- `make check` passed, including Python 3.10–3.14 typechecking/tests, tutorial tests, coverage, lint, docs, links, and build