### PR TITLE
Prepare 7.1.2 CI compatibility release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,17 @@ Please follow [the Keep a Changelog standard](https://keepachangelog.com/en/1.0.
 
 ## [Unreleased]
 
+## [7.1.2]
+
 ### Changed
 
 - Simplified contributor setup and development commands (#387)
 - Standardized test names around the `what`, `when`, and `expected` convention and documented test organization (#397)
 - Expanded Ruff coverage, including return annotations, preview correctness checks, and explicit tracking of reviewed rules
+
+### Fixed
+
+- Restored compatibility with FastAPI 0.140.2+ after it stopped retaining flattened dependency trees
 
 ## [7.1.1]
 

--- a/cadwyn/route_generation.py
+++ b/cadwyn/route_generation.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
     Any,
+    Final,
     Generic,
     Union,
     cast,
@@ -53,6 +54,7 @@ _WR = TypeVar("_WR", bound=APIRouter, default=APIRouter)
 _RouteT = TypeVar("_RouteT", bound=BaseRoute)
 # This is a hack we do because we can't guarantee how the user will use the router.
 _DELETED_ROUTE_TAG = "_CADWYN_DELETED_ROUTE"
+_FLAT_DEPENDANT_ATTR: Final = "_flat_dependant"
 _RoutePath = str
 _RouteMethod = str
 _RouteId = int
@@ -137,7 +139,7 @@ def copy_route(route: _RouteT, effective_route_context: _EffectiveRouteContext |
     # These can hold TypeAdapters for recursive types (e.g. JsonValue) that cause
     # infinite recursion during deepcopy.
     memo: dict[int, Any] = {}
-    for attr in ("dependant", "_flat_dependant", "body_field", "response_model", "dependency_overrides_provider"):
+    for attr in ("dependant", _FLAT_DEPENDANT_ATTR, "body_field", "response_model", "dependency_overrides_provider"):
         obj = getattr(route, attr, None)
         if obj is not None:
             memo[id(obj)] = obj
@@ -147,8 +149,9 @@ def copy_route(route: _RouteT, effective_route_context: _EffectiveRouteContext |
         _refresh_route_app(new_route)
     else:
         new_route.dependant = copy(route.dependant)
-        if getattr(route, "_flat_dependant", None) is not None:
-            new_route._flat_dependant = copy(route._flat_dependant)
+        flat_dependant = getattr(route, _FLAT_DEPENDANT_ATTR, None)
+        if flat_dependant is not None:
+            setattr(new_route, _FLAT_DEPENDANT_ATTR, copy(flat_dependant))
         new_route.body_field = route.body_field
         new_route.dependencies = copy(route.dependencies)
     return new_route
@@ -162,7 +165,7 @@ def _apply_effective_route_context_to_route(route: APIRoute, effective_route_con
 
 
 def _copy_effective_route_context_attr(attr_name: str, attr_value: Any) -> Any:
-    if attr_name in {"dependant", "_flat_dependant"} and attr_value is not None:
+    if attr_name in {"dependant", _FLAT_DEPENDANT_ATTR} and attr_value is not None:
         return copy(attr_value)
     if isinstance(attr_value, dict | list | set):
         return copy(attr_value)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cadwyn"
-version = "7.1.1"
+version = "7.1.2"
 description = "Production-ready community-driven modern Stripe-like API versioning in FastAPI"
 authors = [{ name = "Stanislav Zmiev", email = "zmievsa@gmail.com" }]
 license = "MIT"

--- a/tests/_resources/render/complex/versions.py
+++ b/tests/_resources/render/complex/versions.py
@@ -12,6 +12,8 @@ from .classes import A, AlmostEmptyEnum, ModelWithWeirdFields, MyEnum
 
 class MyVersionChange(VersionChange):
     description = ""
+    # Keep inspect.getsource() starting with `.had`.
+    # fmt: off
     instructions_to_migrate_to_previous_version = (
         enum(MyEnum).didnt_have("baz"),
         enum(AlmostEmptyEnum).didnt_have("foo"),
@@ -21,8 +23,9 @@ class MyVersionChange(VersionChange):
         .existed_as(type=conbytes(strict=True), info=Field(min_length=3, title="Hewwo")),
         schema(ModelWithWeirdFields)
         .field("taz")
-        .had(default_factory=lambda: 91),  # fmt: skip  # Keep inspect.getsource() starting with `.had`.
+        .had(default_factory=lambda: 91),
     )
+    # fmt: on
 
 
 app = Cadwyn(

--- a/tests/test_router_generation.py
+++ b/tests/test_router_generation.py
@@ -1815,11 +1815,26 @@ def test__router_generation__using_svcs_in_dependencies(
     assert len(routes_2000) == len(routes_2001) == 2
 
 
-def test__copy_route__without_flat_dependant():
-    """Test that copy_route works correctly when the route doesn't have _flat_dependant."""
+def test__copy_route__when_route_has_no_flat_dependant__then_copies_route():
     route = APIRoute("/test", lambda: None)
-    # Simulate an older FastAPI version where _flat_dependant doesn't exist
-    del route._flat_dependant
+    flat_dependant_attr = "_flat_dependant"
+    setattr(route, flat_dependant_attr, route.dependant)
+    delattr(route, flat_dependant_attr)
+
     copied = copy_route(route)
+
     assert copied.path == route.path
-    assert not hasattr(copied, "_flat_dependant")
+    assert not hasattr(copied, flat_dependant_attr)
+
+
+def test__copy_route__when_route_has_flat_dependant__then_copies_flat_dependant():
+    route = APIRoute("/test", lambda: None)
+    flat_dependant = route.dependant
+    flat_dependant_attr = "_flat_dependant"
+    setattr(route, flat_dependant_attr, flat_dependant)
+
+    copied = copy_route(route)
+
+    copied_flat_dependant = getattr(copied, flat_dependant_attr)
+    assert copied_flat_dependant is not flat_dependant
+    assert copied_flat_dependant.call is flat_dependant.call

--- a/uv.lock
+++ b/uv.lock
@@ -116,7 +116,7 @@ wheels = [
 
 [[package]]
 name = "cadwyn"
-version = "7.1.1"
+version = "7.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "backports-strenum", marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary

- restore compatibility across FastAPI versions that do and do not retain `_flat_dependant`
- add regression coverage for both route shapes
- replace the invalid inline Ruff formatter suppression with a valid block suppression
- prepare the changelog and package metadata for Cadwyn 7.1.2

## Root cause

FastAPI 0.140.2 stopped retaining flattened dependency trees, and ty 0.0.64 correctly rejected Cadwyn's direct access to the now-absent private attribute. The current `main` SHA also used a formatter suppression that newer Ruff rejects inside an expression.

## Impact

Scheduled dependency-refresh CI can run against current FastAPI and ty releases while Cadwyn remains compatible with its minimum supported FastAPI version. The release metadata is ready for 7.1.2 publication after this PR is green and merged.

## Validation

- `make check`
- Python 3.10, 3.11, 3.12, 3.13, and 3.14 test environments
- 100% combined coverage
- lint, docs, links, tutorial, and build
- focused copy-route tests against FastAPI 0.137.1