### PR TITLE
Deprecate changelog generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Please follow [the Keep a Changelog standard](https://keepachangelog.com/en/1.0.
 
 ## [Unreleased]
 
+### Deprecated
+
+- Deprecated changelog generation, including the default `GET /changelog` endpoint, `Cadwyn.generate_changelog()`, `cadwyn.hidden()`, and the `changelog_url` and `include_changelog_url_in_schema` constructor arguments. The feature remains available for backwards compatibility.
+
 ## [7.1.2]
 
 ### Changed

--- a/cadwyn/__init__.py
+++ b/cadwyn/__init__.py
@@ -1,7 +1,7 @@
 import importlib.metadata
 
 from .applications import Cadwyn
-from .changelogs import hidden
+from .changelogs import hidden  # ty: ignore[deprecated]  # Re-export the deprecated API for compatibility.
 from .dependencies import current_dependency_solver
 from .route_generation import VersionedAPIRouter, generate_versioned_routers
 from .schema_generation import generate_versioned_models, migrate_response_body

--- a/cadwyn/applications.py
+++ b/cadwyn/applications.py
@@ -29,7 +29,7 @@ from starlette.types import Lifespan
 from typing_extensions import Self, assert_never, deprecated, override
 
 from cadwyn._utils import DATACLASS_SLOTS, same_method_definition_as_in
-from cadwyn.changelogs import CadwynChangelogResource, _generate_changelog
+from cadwyn.changelogs import _CHANGELOG_DEPRECATION_MESSAGE, CadwynChangelogResource, _generate_changelog
 from cadwyn.exceptions import CadwynStructureError
 from cadwyn.middleware import (
     APIVersionFormat,
@@ -94,8 +94,8 @@ class Cadwyn(FastAPI):
         api_version_title: Optional[str] = None,
         api_version_description: Optional[str] = None,
         versioning_middleware_class: type[VersionPickingMiddleware] = VersionPickingMiddleware,
-        changelog_url: Union[str, None] = "/changelog",
-        include_changelog_url_in_schema: bool = True,
+        changelog_url: Annotated[Union[str, None], deprecated(_CHANGELOG_DEPRECATION_MESSAGE)] = "/changelog",
+        include_changelog_url_in_schema: Annotated[bool, deprecated(_CHANGELOG_DEPRECATION_MESSAGE)] = True,
         debug: bool = False,
         title: str = "FastAPI",
         summary: Union[str, None] = None,
@@ -160,6 +160,12 @@ class Cadwyn(FastAPI):
                 stacklevel=2,
             )
             api_version_parameter_name = api_version_header_name
+        if changelog_url is not None:
+            warnings.warn(
+                _CHANGELOG_DEPRECATION_MESSAGE,
+                DeprecationWarning,
+                stacklevel=2,
+            )
         if api_version_default_value is not None and api_version_location == "path":
             raise CadwynStructureError(
                 "You tried to pass an api_version_default_value while putting the API version in Path. "
@@ -339,6 +345,7 @@ class Cadwyn(FastAPI):
     ) -> None:
         self._dependency_overrides_provider.dependency_overrides = value
 
+    @deprecated(_CHANGELOG_DEPRECATION_MESSAGE)
     def generate_changelog(self) -> CadwynChangelogResource:
         return _generate_changelog(self.versions, self.router)
 
@@ -346,10 +353,11 @@ class Cadwyn(FastAPI):
         if self.changelog_url is not None:
             unversioned_router.add_api_route(
                 path=self.changelog_url,
-                endpoint=self.generate_changelog,
+                endpoint=self.generate_changelog,  # ty: ignore[deprecated]  # Keep serving the legacy endpoint.
                 response_model=CadwynChangelogResource,
                 methods=["GET"],
                 include_in_schema=self.include_changelog_url_in_schema,
+                deprecated=True,
             )
 
         if self.openapi_url is not None:

--- a/cadwyn/applications.py
+++ b/cadwyn/applications.py
@@ -357,7 +357,6 @@ class Cadwyn(FastAPI):
                 response_model=CadwynChangelogResource,
                 methods=["GET"],
                 include_in_schema=self.include_changelog_url_in_schema,
-                deprecated=True,
             )
 
         if self.openapi_url is not None:

--- a/cadwyn/changelogs.py
+++ b/cadwyn/changelogs.py
@@ -13,6 +13,7 @@ from fastapi.openapi.utils import (
 )
 from fastapi.routing import APIRoute
 from pydantic import BaseModel, Field, RootModel
+from typing_extensions import deprecated
 
 from cadwyn._asts import GenericAliasUnionArgs
 from cadwyn._utils import Sentinel
@@ -45,9 +46,12 @@ else:  # pragma: no cover
 
 _logger = getLogger(__name__)
 
+_CHANGELOG_DEPRECATION_MESSAGE = "Cadwyn's changelog feature is deprecated and will be removed in a future version."
+
 T = TypeVar("T", bound=Union[PossibleInstructions, type[VersionChange]])
 
 
+@deprecated(_CHANGELOG_DEPRECATION_MESSAGE)
 def hidden(instruction_or_version_change: T) -> T:
     if isinstance(instruction_or_version_change, _HiddenAttributeMixin):
         # Weird ty bug, or I am dumb.

--- a/docs/concepts/changelogs.md
+++ b/docs/concepts/changelogs.md
@@ -1,10 +1,14 @@
 # Changelogs
 
-Cadwyn can automatically generate API changelogs for your versions. By default, they are available through the unversioned endpoint `GET /changelog`. You can also access it via `Cadwyn.generate_changelog()` method.
+!!! warning "Deprecated"
+
+    Cadwyn's changelog feature is deprecated and will be removed in a future version. It remains available for backwards compatibility, but new applications should maintain and expose their own changelog instead. Pass `changelog_url=None` to `Cadwyn()` to disable the deprecated endpoint.
+
+Cadwyn can automatically generate API changelogs for your versions. By default, they are available through the deprecated unversioned endpoint `GET /changelog`. You can also access it via the deprecated `Cadwyn.generate_changelog()` method.
 
 ## Hiding version changes and instructions
 
-Sometimes you might want to make private internal version changes or instructions within the version changes that should not be visible to the public. You can do this by using the `cadwyn.hidden()` function. Consider the example below:
+Sometimes you might want to make private internal version changes or instructions within the version changes that should not be visible to the public. You can do this by using the deprecated `cadwyn.hidden()` function. Consider the example below:
 
 ```python
 from cadwyn import VersionChange, endpoint, hidden
@@ -33,11 +37,11 @@ class RemoveAddressFromUser(VersionChange):
 
 ## Customizing changelog endpoint
 
-The changelog endpoint name can be customized by specifying a new name via the `changelog_url` argument to the `Cadwyn()` constructor. Accessing this url via the `GET` request will return the changelog for all versions based on the content of your `VersionBundle`.
+The deprecated changelog endpoint name can be customized by specifying a new name via the deprecated `changelog_url` argument to the `Cadwyn()` constructor. Accessing this URL via a `GET` request will return the changelog for all versions based on the content of your `VersionBundle`.
 
-If you want to hide the changelog endpoint, pass `include_changelog_url_in_schema=False` to `Cadwyn()`.
+If you want to hide the changelog endpoint, pass the deprecated `include_changelog_url_in_schema=False` argument to `Cadwyn()`.
 
-If you want to delete the changelog endpoint, pass `changelog_url=None` to `Cadwyn()`.
+If you want to disable the changelog endpoint, pass `changelog_url=None` to `Cadwyn()`.
 
 ## Changelog structure and entry types
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -127,7 +127,7 @@ nav:
       - "Enum migrations": "concepts/enum_migrations.md"
       - "Schema migrations": "concepts/schema_migrations.md"
       - "API Version parameter": "concepts/api_version_parameter.md"
-      - "Changelogs": "concepts/changelogs.md"
+      - "Changelogs (deprecated)": "concepts/changelogs.md"
       - "Testing": concepts/testing.md
   - "Contributing": "home/CONTRIBUTING.md"
   - "Changelog": "home/CHANGELOG.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,6 +156,9 @@ filterwarnings = [
     "ignore:The `name` is not the first parameter anymore:DeprecationWarning:starlette.templating",
     "ignore:The on_startup and on_shutdown parameters are deprecated:DeprecationWarning:starlette.routing",
 
+    # Most tests construct Cadwyn with its backwards-compatible default changelog endpoint.
+    "ignore:Cadwyn's changelog feature is deprecated and will be removed in a future version.:DeprecationWarning",
+
     # FastAPI still uses httpx, we cannot fix it
     "ignore: Using `httpx` with `starlette.testclient` is deprecated; install `httpx2` instead",
 

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -1,8 +1,11 @@
 import uuid
+import warnings
 from enum import IntEnum, auto
 from typing import Any, Union
 
+import pytest
 from dirty_equals import IsList
+from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
 from pydantic import BaseModel, Field, field_validator
 
@@ -15,14 +18,60 @@ from cadwyn import (
     schema,
 )
 from cadwyn.applications import Cadwyn
-from cadwyn.changelogs import ChangelogEntryType, StrEnum, hidden
+from cadwyn.changelogs import (
+    ChangelogEntryType,
+    StrEnum,
+    hidden,  # ty: ignore[deprecated]  # Legacy API exercised throughout this module.
+)
 from cadwyn.route_generation import VersionedAPIRouter
 from cadwyn.structure.enums import enum
 from tests.conftest import CreateVersionedApp, version_change
 
+CHANGELOG_DEPRECATION_MESSAGE = "Cadwyn's changelog feature is deprecated"
+
 
 def unordered(*items: Any):
     return IsList(*items, check_order=False)
+
+
+def test__changelog__when_enabled__warns_and_marks_endpoint_as_deprecated():
+    with pytest.warns(DeprecationWarning, match=CHANGELOG_DEPRECATION_MESSAGE):
+        app = Cadwyn(versions=VersionBundle(Version("2022-11-16")))
+
+    changelog_route = next(route for route in app.routes if getattr(route, "path", None) == "/changelog")
+    assert isinstance(changelog_route, APIRoute)
+    assert changelog_route.deprecated is True
+
+    with TestClient(app) as client:
+        openapi_response = client.get("/openapi.json?version=unversioned")
+        with pytest.warns(DeprecationWarning, match=CHANGELOG_DEPRECATION_MESSAGE):
+            response = client.get("/changelog")
+
+    assert response.status_code == 200
+    assert openapi_response.json()["paths"]["/changelog"]["get"]["deprecated"] is True
+
+
+def test__changelog__when_disabled__does_not_warn_or_add_endpoint():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        app = Cadwyn(changelog_url=None, versions=VersionBundle(Version("2022-11-16")))
+
+    assert all(getattr(route, "path", None) != "/changelog" for route in app.routes)
+
+
+def test__generate_changelog__when_called__warns():
+    with pytest.warns(DeprecationWarning, match=CHANGELOG_DEPRECATION_MESSAGE):
+        app = Cadwyn(versions=VersionBundle(Version("2022-11-16")))
+
+    with pytest.warns(DeprecationWarning, match=CHANGELOG_DEPRECATION_MESSAGE):
+        app.generate_changelog()  # ty: ignore[deprecated]  # This test verifies the legacy API.
+
+
+def test__hidden__when_called__warns():
+    instruction = schema(BaseModel).field("field").didnt_exist
+
+    with pytest.warns(DeprecationWarning, match=CHANGELOG_DEPRECATION_MESSAGE):
+        assert hidden(instruction) is instruction  # ty: ignore[deprecated]  # This test verifies the legacy API.
 
 
 def test__changelog__with_multiple_versions():
@@ -185,7 +234,7 @@ def test__changelog__enum_interactions(create_versioned_app: CreateVersionedApp)
         ),
     )
 
-    assert app.generate_changelog().model_dump(mode="json")["versions"][0]["changes"][0]["instructions"] == [
+    assert app.generate_changelog().model_dump(mode="json")["versions"][0]["changes"][0]["instructions"] == [  # ty: ignore[deprecated]  # Legacy API coverage.
         {
             "type": ChangelogEntryType.enum_members_added,
             "enum": "MyIntEnum",
@@ -238,12 +287,14 @@ def test__changelog__basic_schema_interactions(create_versioned_app: CreateVersi
             schema(SchemaWithSomeField).field("some_field").had(min_length=30, deprecated=True),
             schema(SchemaWithSomeField).field("some_field").had(max_length=50, name="HELLO"),
             schema(SchemaChild).validator(SchemaChild.my_validator).didnt_exist,
-            hidden(schema(SchemaWithSomeField).field("hewwwo").existed_as(type=str, info=Field(min_length=45))),
+            hidden(  # ty: ignore[deprecated]  # Legacy API coverage.
+                schema(SchemaWithSomeField).field("hewwwo").existed_as(type=str, info=Field(min_length=45))
+            ),
         ),
         router=router,
     )
 
-    assert app.generate_changelog().model_dump(mode="json")["versions"][0]["changes"][0]["instructions"] == [
+    assert app.generate_changelog().model_dump(mode="json")["versions"][0]["changes"][0]["instructions"] == [  # ty: ignore[deprecated]  # Legacy API coverage.
         {
             "type": ChangelogEntryType.schema_changed,
             "model": "UWU",
@@ -320,7 +371,7 @@ def test__changelog__basic_endpoint_interactions(create_versioned_app: CreateVer
         router=router,
     )
 
-    assert app.generate_changelog().model_dump(mode="json")["versions"][0]["changes"][0]["instructions"] == [
+    assert app.generate_changelog().model_dump(mode="json")["versions"][0]["changes"][0]["instructions"] == [  # ty: ignore[deprecated]  # Legacy API coverage.
         {
             "type": ChangelogEntryType.endpoint_changed,
             "path": "/route1",
@@ -400,14 +451,18 @@ def test__changelog__with_hidden_instructions(create_versioned_app: CreateVersio
 
     app = create_versioned_app(
         version_change(
-            hidden(schema(SchemaWithSomeField).had(name="UWU")),
-            hidden(schema(SchemaWithSomeField).validator(SchemaWithSomeField.my_validator).didnt_exist),
+            hidden(schema(SchemaWithSomeField).had(name="UWU")),  # ty: ignore[deprecated]  # Legacy API coverage.
+            hidden(  # ty: ignore[deprecated]  # Legacy API coverage.
+                schema(SchemaWithSomeField).validator(SchemaWithSomeField.my_validator).didnt_exist
+            ),
         ),
-        hidden(version_change(schema(SchemaWithSomeField).had(name="AWAW"))),
+        hidden(  # ty: ignore[deprecated]  # Legacy API coverage.
+            version_change(schema(SchemaWithSomeField).had(name="AWAW"))
+        ),
         router=router,
     )
 
-    assert app.generate_changelog().model_dump(mode="json")["versions"] == [
+    assert app.generate_changelog().model_dump(mode="json")["versions"] == [  # ty: ignore[deprecated]  # Legacy API coverage.
         {"value": "2002-01-01", "changes": []},
         {"value": "2001-01-01", "changes": [{"description": "", "side_effects": False, "instructions": []}]},
     ]
@@ -435,7 +490,7 @@ def test__changelog__with_child_overriding_changed_field_in_parent__unused_model
         router=router,
     )
 
-    assert app.generate_changelog().model_dump(mode="json")["versions"] == [
+    assert app.generate_changelog().model_dump(mode="json")["versions"] == [  # ty: ignore[deprecated]  # Legacy API coverage.
         {
             "value": "2001-01-01",
             "changes": [

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -5,7 +5,6 @@ from typing import Any, Union
 
 import pytest
 from dirty_equals import IsList
-from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
 from pydantic import BaseModel, Field, field_validator
 
@@ -34,21 +33,14 @@ def unordered(*items: Any):
     return IsList(*items, check_order=False)
 
 
-def test__changelog__when_enabled__warns_and_marks_endpoint_as_deprecated():
+def test__changelog__when_enabled__warns_and_endpoint_still_works():
     with pytest.warns(DeprecationWarning, match=CHANGELOG_DEPRECATION_MESSAGE):
         app = Cadwyn(versions=VersionBundle(Version("2022-11-16")))
 
-    changelog_route = next(route for route in app.routes if getattr(route, "path", None) == "/changelog")
-    assert isinstance(changelog_route, APIRoute)
-    assert changelog_route.deprecated is True
-
-    with TestClient(app) as client:
-        openapi_response = client.get("/openapi.json?version=unversioned")
-        with pytest.warns(DeprecationWarning, match=CHANGELOG_DEPRECATION_MESSAGE):
-            response = client.get("/changelog")
+    with TestClient(app) as client, pytest.warns(DeprecationWarning, match=CHANGELOG_DEPRECATION_MESSAGE):
+        response = client.get("/changelog")
 
     assert response.status_code == 200
-    assert openapi_response.json()["paths"]["/changelog"]["get"]["deprecated"] is True
 
 
 def test__changelog__when_disabled__does_not_warn_or_add_endpoint():


### PR DESCRIPTION
## Summary

- emit deprecation warnings when Cadwyn changelog generation is enabled or invoked
- mark `Cadwyn.generate_changelog()`, `cadwyn.hidden()`, and changelog configuration parameters as deprecated for static tooling
- document the deprecation and the `changelog_url=None` opt-out while preserving backwards compatibility
- add regression coverage for warnings, compatibility, and warning-free opt-out

## Why

Cadwyn's automatic changelog feature is being deprecated ahead of eventual removal. Existing applications must continue to work during the deprecation period while new applications receive clear runtime, typing, and documentation signals.

## Validation

- `make check`
  - tests and type checking on Python 3.10–3.14
  - tutorial and coverage
  - lint
  - strict documentation build and link checking
  - package build