### PR TITLE
Fix broken Starlette documentation links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Please follow [the Keep a Changelog standard](https://keepachangelog.com/en/1.0.
 
 - Added native View Transition API animations to documentation navigation, with reduced-motion and unsupported-browser fallbacks.
 
+### Changed
+
+- Updated Starlette documentation links to the project's current official domain.
+
 ## [7.2.0]
 
 ### Deprecated

--- a/docs/concepts/version_changes.md
+++ b/docs/concepts/version_changes.md
@@ -300,8 +300,8 @@ Cadwyn can migrate more than just request bodies.
 * `body: Any`
 * `status_code: int`
 * `headers: starlette.datastructures.MutableHeaders`
-* [set_cookie](https://www.starlette.io/responses/#set-cookie)
-* [delete_cookie](https://www.starlette.io/responses/#delete-cookie)
+* [set_cookie](https://starlette.dev/responses/#set-cookie)
+* [delete_cookie](https://starlette.dev/responses/#delete-cookie)
 
 #### Internal representations
 


### PR DESCRIPTION
## Summary

- replace two dead `starlette.io` links with the current official `starlette.dev` URLs
- record the documentation update in the changelog

## Validation

- `uv run tox run -e docs`
- `npx --yes @umbrelladocs/linkspector@0.5.5 check`