### PR TITLE
Preserve classmethod binding of serializers during model generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Please follow [the Keep a Changelog standard](https://keepachangelog.com/en/1.0.
 ### Fixed
 
 - Restored compatibility with ty 0.0.78 while preserving FastAPI's coroutine detection on every supported Python version.
+- Preserved the `classmethod` binding of `@field_serializer` decorators during model generation. Previously, such serializers were re-registered as instance methods, shifting their arguments by one and raising `PydanticSerializationError` on every serialization.
 
 ## [7.2.0]
 

--- a/cadwyn/schema_generation.py
+++ b/cadwyn/schema_generation.py
@@ -223,6 +223,7 @@ class _ValidatorWrapper:
     func: Callable[..., object]
     decorator: Callable[..., Callable[..., object]]
     is_deleted: bool = False
+    is_classmethod: bool = False
 
 
 @dataclasses.dataclass(**DATACLASS_SLOTS, **DATACLASS_KW_ONLY)
@@ -237,7 +238,9 @@ def _wrap_validator(
 ):
     # This is only for pydantic v1 style validators
     func = fully_unwrap_decorator(func, is_pydantic_v1_style_validator)
+    is_classmethod = False
     if inspect.ismethod(func):
+        is_classmethod = True
         func = func.__func__
     kwargs = dataclasses.asdict(decorator_info)
     decorator_fields = kwargs.pop("fields", None)
@@ -257,10 +260,14 @@ def _wrap_validator(
             kwargs["skip_on_failure"] = True
     if decorator_fields is not None:
         return _PerFieldValidatorWrapper(
-            func=func, fields=list(decorator_fields), decorator=actual_decorator, kwargs=kwargs
+            func=func,
+            fields=list(decorator_fields),
+            decorator=actual_decorator,
+            kwargs=kwargs,
+            is_classmethod=is_classmethod,
         )
     else:
-        return _ValidatorWrapper(func=func, decorator=actual_decorator, kwargs=kwargs)
+        return _ValidatorWrapper(func=func, decorator=actual_decorator, kwargs=kwargs, is_classmethod=is_classmethod)
 
 
 def _is_dunder(attr_name: str):
@@ -422,10 +429,11 @@ class _PydanticModelWrapper(Generic[_T_PYDANTIC_MODEL]):
         for name, validator in self.validators.items():
             if validator.is_deleted:
                 continue
+            func = classmethod(validator.func) if validator.is_classmethod else validator.func
             if isinstance(validator, _PerFieldValidatorWrapper):
-                per_field_validators[name] = validator.decorator(*validator.fields, **validator.kwargs)(validator.func)
+                per_field_validators[name] = validator.decorator(*validator.fields, **validator.kwargs)(func)
             else:
-                root_validators[name] = validator.decorator(**validator.kwargs)(validator.func)
+                root_validators[name] = validator.decorator(**validator.kwargs)(func)
         fields = {name: field.generate_field_copy(generator) for name, field in self.fields.items()}
 
         model_copy = type(self.cls)(

--- a/tests/test_schema_generation/test_schema_validator.py
+++ b/tests/test_schema_generation/test_schema_validator.py
@@ -256,7 +256,7 @@ def test__validator_didnt_exist__with_validator_defined_in_parent__should_raise_
         create_runtime_schemas(version_change(schema(B).validator(A.validate_foo).didnt_exist))
 
 
-def test__schema_generation__with_classmethod_field_serializer__classmethod_binding_is_preserved(
+def test__schema_generation__with_classmethod_field_serializer__generated_model_serializes_like_the_original(
     create_runtime_schemas: CreateRuntimeSchemas,
 ):
     class SchemaWithClassmethodFieldSerializer(BaseModel):
@@ -268,12 +268,14 @@ def test__schema_generation__with_classmethod_field_serializer__classmethod_bind
             return value.upper()
 
     schemas = create_runtime_schemas(version_change())
+    original_dump = SchemaWithClassmethodFieldSerializer(foo="hello").model_dump()
 
-    assert schemas["2000-01-01"][SchemaWithClassmethodFieldSerializer](foo="hello").model_dump() == {"foo": "HELLO"}
-    assert schemas["2001-01-01"][SchemaWithClassmethodFieldSerializer](foo="hello").model_dump() == {"foo": "HELLO"}
+    assert original_dump == {"foo": "HELLO"}
+    assert schemas["2000-01-01"][SchemaWithClassmethodFieldSerializer](foo="hello").model_dump() == original_dump
+    assert schemas["2001-01-01"][SchemaWithClassmethodFieldSerializer](foo="hello").model_dump() == original_dump
 
 
-def test__schema_generation__with_classmethod_wrap_field_serializer__classmethod_binding_is_preserved(
+def test__schema_generation__with_classmethod_wrap_field_serializer__generated_model_serializes_like_the_original(
     create_runtime_schemas: CreateRuntimeSchemas,
 ):
     class SchemaWithClassmethodWrapFieldSerializer(BaseModel):
@@ -285,7 +287,45 @@ def test__schema_generation__with_classmethod_wrap_field_serializer__classmethod
             return handler(value) + "_serialized"
 
     schemas = create_runtime_schemas(version_change())
+    original_dump = SchemaWithClassmethodWrapFieldSerializer(foo="hello").model_dump()
 
-    assert schemas["2000-01-01"][SchemaWithClassmethodWrapFieldSerializer](foo="hello").model_dump() == {
-        "foo": "hello_serialized"
-    }
+    assert original_dump == {"foo": "hello_serialized"}
+    assert schemas["2000-01-01"][SchemaWithClassmethodWrapFieldSerializer](foo="hello").model_dump() == original_dump
+
+
+def test__schema_generation__with_staticmethod_field_serializer__generated_model_serializes_like_the_original(
+    create_runtime_schemas: CreateRuntimeSchemas,
+):
+    class SchemaWithStaticmethodFieldSerializer(BaseModel):
+        foo: str
+
+        @field_serializer("foo")
+        @staticmethod
+        def serialize_foo(value: str) -> str:
+            return value.upper()
+
+    schemas = create_runtime_schemas(version_change())
+    original_dump = SchemaWithStaticmethodFieldSerializer(foo="hello").model_dump()
+
+    assert original_dump == {"foo": "HELLO"}
+    assert schemas["2000-01-01"][SchemaWithStaticmethodFieldSerializer](foo="hello").model_dump() == original_dump
+    assert schemas["2001-01-01"][SchemaWithStaticmethodFieldSerializer](foo="hello").model_dump() == original_dump
+
+
+def test__schema_generation__with_staticmethod_field_validator__generated_model_validates_like_the_original(
+    create_runtime_schemas: CreateRuntimeSchemas,
+):
+    class SchemaWithStaticmethodFieldValidator(BaseModel):
+        foo: str
+
+        @field_validator("foo")
+        @staticmethod
+        def validate_foo(value: str) -> str:
+            return value + "_validated"
+
+    schemas = create_runtime_schemas(version_change())
+    original_foo = SchemaWithStaticmethodFieldValidator(foo="hello").foo
+
+    assert original_foo == "hello_validated"
+    assert schemas["2000-01-01"][SchemaWithStaticmethodFieldValidator](foo="hello").foo == original_foo
+    assert schemas["2001-01-01"][SchemaWithStaticmethodFieldValidator](foo="hello").foo == original_foo

--- a/tests/test_schema_generation/test_schema_validator.py
+++ b/tests/test_schema_generation/test_schema_validator.py
@@ -1,8 +1,10 @@
 import re
+from typing import Any
 
 import pytest
 from pydantic import (
     BaseModel,
+    field_serializer,
     field_validator,
     model_validator,
     root_validator,  # ty: ignore[deprecated]  # Tests intentionally cover Pydantic v1 validators.
@@ -252,3 +254,38 @@ def test__validator_didnt_exist__with_validator_defined_in_parent__should_raise_
         ),
     ):
         create_runtime_schemas(version_change(schema(B).validator(A.validate_foo).didnt_exist))
+
+
+def test__schema_generation__with_classmethod_field_serializer__classmethod_binding_is_preserved(
+    create_runtime_schemas: CreateRuntimeSchemas,
+):
+    class SchemaWithClassmethodFieldSerializer(BaseModel):
+        foo: str
+
+        @field_serializer("foo")
+        @classmethod
+        def serialize_foo(cls, value: str) -> str:
+            return value.upper()
+
+    schemas = create_runtime_schemas(version_change())
+
+    assert schemas["2000-01-01"][SchemaWithClassmethodFieldSerializer](foo="hello").model_dump() == {"foo": "HELLO"}
+    assert schemas["2001-01-01"][SchemaWithClassmethodFieldSerializer](foo="hello").model_dump() == {"foo": "HELLO"}
+
+
+def test__schema_generation__with_classmethod_wrap_field_serializer__classmethod_binding_is_preserved(
+    create_runtime_schemas: CreateRuntimeSchemas,
+):
+    class SchemaWithClassmethodWrapFieldSerializer(BaseModel):
+        foo: str
+
+        @field_serializer("foo", mode="wrap")
+        @classmethod
+        def serialize_foo(cls, value: str, handler: Any) -> str:
+            return handler(value) + "_serialized"
+
+    schemas = create_runtime_schemas(version_change())
+
+    assert schemas["2000-01-01"][SchemaWithClassmethodWrapFieldSerializer](foo="hello").model_dump() == {
+        "foo": "hello_serialized"
+    }


### PR DESCRIPTION
## Summary

When a Pydantic model uses a serializer decorated as a `@classmethod` (`@field_serializer(...)` over `@classmethod`), Cadwyn's model regeneration dropped the `classmethod` binding, so the serializer was re-registered as a plain instance method. Its arguments then shifted by one and it was called with a `SerializationInfo` where it expected the value (or handler, in `mode="wrap"`), raising `PydanticSerializationError` on every serialization of the generated model.

Validators were unaffected because `pydantic.field_validator` re-wraps plain functions into classmethods internally; `pydantic.field_serializer` registers the function as-is, so only serializers broke.

## Reproduction

```python
from pydantic import BaseModel, field_serializer
from fastapi.testclient import TestClient
from cadwyn import Cadwyn, Version, VersionBundle, VersionedAPIRouter


class M(BaseModel):
    x: str

    @field_serializer("x")
    @classmethod
    def ser_x(cls, v: str) -> str:
        return v.upper()


router = VersionedAPIRouter()


@router.get("/m")
def get_m() -> M:
    return M(x="hi")


app = Cadwyn(versions=VersionBundle(Version("2000-01-01")))
app.generate_and_include_versioned_routers(router)

print(TestClient(app).get("/m", headers={"x-api-version": "2000-01-01"}).json())
```

Expected `{"x": "HI"}`; before this fix it returned a 500 with:

```
PydanticSerializationError: Error calling function `ser_x`:
AttributeError: 'pydantic_core._pydantic_core.SerializationInfo' object has no attribute 'upper'
```

## Root cause and fix

In `cadwyn/schema_generation.py`, `_wrap_validator` unwrapped the bound method and kept only the underlying function (`func = func.__func__`) without recording that the original was a `classmethod`. `generate_model_copy` then re-applied the pydantic decorator to the bare function, registering it as an instance method.

The fix records the binding in a new `is_classmethod` field on `_ValidatorWrapper` at the point of the strip, and `generate_model_copy` re-wraps the function with `classmethod(...)` before re-applying the decorator.

## Notes

- Added regression tests for plain and `mode="wrap"` classmethod field serializers.
- The `@model_serializer` + `@classmethod` combination is not covered because pydantic itself rejects it at class definition time (`model-serializer-instance-method`), so it can never reach Cadwyn.
- Updated `CHANGELOG.md` under Unreleased → Fixed.
